### PR TITLE
Fix for #1786 - creative inventory not generating

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -754,6 +754,14 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         this.inventory.sendContents(this);
         this.inventory.sendArmorContents(this);
 
+        /*
+        * Creative inventory generation moved here by MitchellBot
+        * to resolve Issue #1786
+        */        
+        if(this.isCreative()){
+        this.inventory.sendCreativeContents(this);
+        }
+        
         SetTimePacket setTimePacket = new SetTimePacket();
         setTimePacket.time = this.level.getTime();
         this.dataPacket(setTimePacket);
@@ -1952,19 +1960,6 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
             this.setRemoveFormat(false);
         }
 
-        if (this.gamemode == Player.SPECTATOR) {
-            ContainerSetContentPacket containerSetContentPacket = new ContainerSetContentPacket();
-            containerSetContentPacket.windowid = ContainerSetContentPacket.SPECIAL_CREATIVE;
-            containerSetContentPacket.eid = this.id;
-            this.dataPacket(containerSetContentPacket);
-        } else {
-            ContainerSetContentPacket containerSetContentPacket = new ContainerSetContentPacket();
-            containerSetContentPacket.windowid = ContainerSetContentPacket.SPECIAL_CREATIVE;
-            containerSetContentPacket.eid = this.id;
-            containerSetContentPacket.slots = Item.getCreativeItems().stream().toArray(Item[]::new);
-            this.dataPacket(containerSetContentPacket);
-        }
-
         this.setEnableClientCommand(true);
 
         this.server.sendFullPlayerListData(this);
@@ -1972,6 +1967,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         this.forceMovement = this.teleportPosition = this.getPosition();
 
         this.server.onPlayerLogin(this);
+
     }
 
     public void handleDataPacket(DataPacket packet) {

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -669,7 +669,20 @@ public class Server {
         if (this.getPropertyBoolean("hardcore", false) && this.getDifficulty() < 3) {
             this.setPropertyInt("difficulty", 3);
         }
-
+        
+        /*
+        * Regeneration of creative inventory added to 
+        * the reload command in case of #1786 regression
+        * reloads creative inventory for *all* connected players
+        */        
+        if((this.getGamemode() & 0x01) > 0) 
+        {
+            this.logger.info("Reloading creative inventory...");
+            for (Player player : this.players.values()){
+                player.getInventory().sendCreativeContents(player);
+            }
+        }
+        
         this.banByIP.load();
         this.banByName.load();
         this.reloadWhitelist();
@@ -813,6 +826,7 @@ public class Server {
     public void onPlayerLogin(Player player) {
         if (this.sendUsageTicker > 0) {
             this.uniquePlayers.add(player.getUniqueId());
+            
         }
     }
 

--- a/src/main/java/cn/nukkit/inventory/PlayerInventory.java
+++ b/src/main/java/cn/nukkit/inventory/PlayerInventory.java
@@ -425,6 +425,21 @@ public class PlayerInventory extends BaseInventory {
         }
     }
 
+    /*
+    * Creative inventory generation moved here by MitchellBot
+    * to resolve Issue #1786
+    */        
+    public void sendCreativeContents(Player player)
+    {
+        ContainerSetContentPacket containerSetContentPacket = new ContainerSetContentPacket();
+        
+        containerSetContentPacket.windowid = ContainerSetContentPacket.SPECIAL_CREATIVE;
+        containerSetContentPacket.eid = this.getHolder().getId();
+        containerSetContentPacket.slots = Item.getCreativeItems().stream().toArray(Item[]::new);
+            
+        player.dataPacket(containerSetContentPacket.clone(), true);
+    }
+    
     @Override
     public void sendSlot(int index, Player player) {
         this.sendSlot(index, new Player[]{player});


### PR DESCRIPTION
- Added sendCreativeContents function to PlayerInventory
- Removed ContainerSetContentPacket logic from ProcessLogin()
- Added call to sendCreativeContents to player during doFirstSpawn()
- Added call to sendCreativeContents to the reload command to regenerate all players' creative inventories