### PR TITLE
Implement authentication for Xbox

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,24 +4,23 @@ pipeline {
         maven 'Maven 3'
         jdk 'Java 8'
     }
+    option {
+        buildDiscarder(logRotator(artifactNumToKeepStr: '10'))
+    }
     stages {
-        stage ('Initialize') {
-            steps {
-                sh '''
-                    echo "PATH = ${PATH}"
-                    echo "M2_HOME = ${M2_HOME}"
-                '''
-            }
-        }
-
         stage ('Build') {
             steps {
-                sh 'mvn clean package install'
+                sh 'mvn clean package install javadoc:javadoc'
             }
             post {
                 success {
-                    junit '**/target/surefire-reports/**/*.xml'
+                    junit 'target/surefire-reports/**/*.xml'
                     archiveArtifacts artifacts: 'target/nukkit-*-SNAPSHOT.jar', fingerprint: true
+                    step([
+                        $class: 'JavadocArchiver',
+                        javadocDir: 'target\site\apidocs',
+                        keepAll: true
+                    ])
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
                     archiveArtifacts artifacts: 'target/nukkit-*-SNAPSHOT.jar', fingerprint: true
                     step([
                         $class: 'JavadocArchiver',
-                        javadocDir: 'target\site\apidocs',
+                        javadocDir: 'target/site/apidocs',
                         keepAll: true
                     ])
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
         maven 'Maven 3'
         jdk 'Java 8'
     }
-    option {
+    options {
         buildDiscarder(logRotator(artifactNumToKeepStr: '10'))
     }
     stages {

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,12 @@
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>4.39.2</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2017,7 +2017,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
                     this.loginChainData = ClientChainData.read(loginPacket);
 
-                    if (server.getPropertyBoolean("xbox-auth")) {
+                    if (!loginChainData.isXboxAuthed() && server.getPropertyBoolean("xbox-auth")) {
                         kick(PlayerKickEvent.Reason.UNKNOWN, "disconnectionScreen.invalidName", false);
                     }
 

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2017,6 +2017,11 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
                     this.loginChainData = ClientChainData.read(loginPacket);
 
+                    if (server.getPropertyBoolean("xbox-auth")) {
+                        kick(PlayerKickEvent.Reason.UNKNOWN, "disconnectionScreen.invalidName", false);
+                    }
+
+
                     if (this.server.getOnlinePlayers().size() >= this.server.getMaxPlayers() && this.kick(PlayerKickEvent.Reason.SERVER_FULL, "disconnectionScreen.serverFull", false)) {
                         break;
                     }

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -291,6 +291,7 @@ public class Server {
                 put("auto-save", true);
                 put("force-resources", false);
                 put("bug-report", true);
+                put("xbox-auth", true);
             }
         });
 

--- a/src/main/java/cn/nukkit/utils/LoginChainData.java
+++ b/src/main/java/cn/nukkit/utils/LoginChainData.java
@@ -29,6 +29,8 @@ public interface LoginChainData {
 
     String getXUID();
 
+    boolean isXboxAuthed();
+
     int getCurrentInputMode();
 
     int getDefaultInputMode();


### PR DESCRIPTION
Validate the JWT chain data with Mojang's Public Key so that spoofed players are not able to join the server unless `xbox-auth` is set to `false`.