### PR TITLE
Support versions lower than 1.2 without throwing errors

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -1990,7 +1990,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     LoginPacket loginPacket = (LoginPacket) packet;
 
                     String message;
-                    if (loginPacket.getProtocol() < ProtocolInfo.CURRENT_PROTOCOL) {
+                    if (!ProtocolInfo.SUPPORTED_PROTOCOLS.contains(loginPacket.getProtocol())) {
                         if (loginPacket.getProtocol() < ProtocolInfo.CURRENT_PROTOCOL) {
                             message = "disconnectionScreen.outdatedClient";
 

--- a/src/main/java/cn/nukkit/network/protocol/LoginPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/LoginPacket.java
@@ -38,6 +38,10 @@ public class LoginPacket extends DataPacket {
     @Override
     public void decode() {
         this.protocol = this.getInt();
+        if (protocol >= 0xffff) {
+            this.offset -= 6;
+            this.protocol = this.getInt();
+        }
         this.setBuffer(this.getByteArray(), 0);
         decodeChainData();
         decodeSkinData();

--- a/src/main/java/cn/nukkit/network/protocol/LoginPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/LoginPacket.java
@@ -41,6 +41,7 @@ public class LoginPacket extends DataPacket {
         if (protocol >= 0xffff) {
             this.offset -= 6;
             this.protocol = this.getInt();
+            this.offset += 1;
         }
         this.setBuffer(this.getByteArray(), 0);
         decodeChainData();

--- a/src/main/java/cn/nukkit/network/protocol/ProtocolInfo.java
+++ b/src/main/java/cn/nukkit/network/protocol/ProtocolInfo.java
@@ -1,5 +1,9 @@
 package cn.nukkit.network.protocol;
 
+import com.google.common.primitives.Ints;
+
+import java.util.List;
+
 /**
  * author: MagicDroidX & iNevet
  * Nukkit Project
@@ -10,6 +14,8 @@ public interface ProtocolInfo {
      * Actual Minecraft: PE protocol version
      */
     int CURRENT_PROTOCOL = Integer.valueOf("160"); //plugins can change it
+
+    List<Integer> SUPPORTED_PROTOCOLS = Ints.asList(140, 141, 150, CURRENT_PROTOCOL);
 
     String MINECRAFT_VERSION = "v1.2.7";
     String MINECRAFT_VERSION_NETWORK = "1.2.7";


### PR DESCRIPTION
This stops the server from throwing errors when a player with version 1.1.x or below joins due to the major change in protocol. Also changed the detection for incompatible protocol versions.