### PR TITLE
don't fill stacktrace for control flow exceptions

### DIFF
--- a/src/main/java/cn/nukkit/utils/ChunkException.java
+++ b/src/main/java/cn/nukkit/utils/ChunkException.java
@@ -10,7 +10,7 @@ public class ChunkException extends RuntimeException {
     }
 
     @Override
-    public synchronized Throwable fillInStackTrace() {
+    public Throwable fillInStackTrace() {
         return this;
     }
 }

--- a/src/main/java/cn/nukkit/utils/ChunkException.java
+++ b/src/main/java/cn/nukkit/utils/ChunkException.java
@@ -8,4 +8,9 @@ public class ChunkException extends RuntimeException {
     public ChunkException(String message) {
         super(message);
     }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
 }


### PR DESCRIPTION
Exceptions used for control flow (e.g. ChunkException) shouldn't fill in their stacktrace. The stacktrace will never be used, and it's relatively expensive to generate. 

there may be other exceptions that need changing