### PR TITLE
Use Block.get instead of reflection fixes #74

### DIFF
--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -930,7 +930,7 @@ public class Item implements Cloneable {
             if (c == null) {
                 item = new Item(id, meta, count);
             } else if (id < 256) {
-                item = new ItemBlock((Block) c.getConstructor(int.class).newInstance(meta), meta, count);
+                item = new ItemBlock(Block.get(id, meta), meta, count);
             } else {
                 item = ((Item) c.getConstructor(Integer.class, int.class).newInstance(meta, count));
             }

--- a/src/main/java/cn/nukkit/level/format/anvil/Chunk.java
+++ b/src/main/java/cn/nukkit/level/format/anvil/Chunk.java
@@ -172,9 +172,9 @@ public class Chunk extends BaseChunk {
                         @SuppressWarnings("unchecked")
                         Class<? extends Block> clazz = (Class<? extends Block>) Class.forName("cn.nukkit.block." + name);
 
-                        Constructor constructor = clazz.getDeclaredConstructor(int.class);
+                        Constructor constructor = clazz.getDeclaredConstructor();
                         constructor.setAccessible(true);
-                        block = (Block) constructor.newInstance(0);
+                        block = (Block) constructor.newInstance();
                     }
                 } catch (Throwable e) {
                     continue;


### PR DESCRIPTION
In my Block restructuring PR I forgot to replace all uses of Reflection with the Block.get method.