### PR TITLE
Disable watchdog if debug.level is 2 or above, to enable breakpoints.

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -490,8 +490,10 @@ public class Server {
 
         this.enablePlugins(PluginLoadOrder.POSTWORLD);
 
-        this.watchdog = new Watchdog(this, 60000);
-        this.watchdog.start();
+        if (Nukkit.DEBUG < 2) {
+            this.watchdog = new Watchdog(this, 60000);
+            this.watchdog.start();
+        }
 
         this.start();
     }


### PR DESCRIPTION
Hi guys!

I'm trying to debug an issue in Nukkit, and the first thing I ran into was that it was difficult to debug. :-)

This patch facilitates debugging with breakpoints and single-stepping, by disabling the watchdog if debug.level is set to at least 2.

If there's another, established way of accomplishing this, please let me know.