### PR TITLE
Minimize the usage of AWT.

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -65,7 +65,6 @@ import cn.nukkit.utils.*;
 import co.aikar.timings.Timing;
 import co.aikar.timings.Timings;
 
-import java.awt.*;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteOrder;
@@ -4125,7 +4124,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
      * @return DummyBossBar object
      * @see DummyBossBar#setText(String) Set BossBar text
      * @see DummyBossBar#setLength(float) Set BossBar length
-     * @see DummyBossBar#setColor(Color) Set BossBar color
+     * @see DummyBossBar#setColor(BlockColor) Set BossBar color
      */
     public DummyBossBar getDummyBossBar(long bossBarId) {
         return this.dummyBossBars.getOrDefault(bossBarId, null);

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityCauldron.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityCauldron.java
@@ -3,8 +3,7 @@ package cn.nukkit.blockentity;
 import cn.nukkit.block.Block;
 import cn.nukkit.level.format.FullChunk;
 import cn.nukkit.nbt.tag.CompoundTag;
-
-import java.awt.*;
+import cn.nukkit.utils.BlockColor;
 
 /**
  * author: CreeperFace
@@ -50,7 +49,7 @@ public class BlockEntityCauldron extends BlockEntitySpawnable {
         namedTag.putByte("SplashPotion", value ? 1 : 0);
     }
 
-    public Color getCustomColor() {
+    public BlockColor getCustomColor() {
         if (isCustomColor()) {
             int color = namedTag.getInt("CustomColor");
 
@@ -58,7 +57,7 @@ public class BlockEntityCauldron extends BlockEntitySpawnable {
             int green = (color >> 8) & 0xff;
             int blue = (color) & 0xff;
 
-            return new Color(red, green, blue);
+            return new BlockColor(red, green, blue);
         }
 
         return null;
@@ -68,7 +67,7 @@ public class BlockEntityCauldron extends BlockEntitySpawnable {
         return namedTag.contains("CustomColor");
     }
 
-    public void setCustomColor(Color color) {
+    public void setCustomColor(BlockColor color) {
         setCustomColor(color.getRed(), color.getGreen(), color.getBlue());
     }
 

--- a/src/main/java/cn/nukkit/entity/data/Skin.java
+++ b/src/main/java/cn/nukkit/entity/data/Skin.java
@@ -2,7 +2,7 @@ package cn.nukkit.entity.data;
 
 import javax.imageio.ImageIO;
 import javax.imageio.stream.ImageInputStream;
-import java.awt.*;
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.File;

--- a/src/main/java/cn/nukkit/item/ItemMap.java
+++ b/src/main/java/cn/nukkit/item/ItemMap.java
@@ -6,7 +6,7 @@ import cn.nukkit.network.protocol.ClientboundMapItemDataPacket;
 import cn.nukkit.utils.MainLogger;
 
 import javax.imageio.ImageIO;
-import java.awt.*;
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/src/main/java/cn/nukkit/network/protocol/ClientboundMapItemDataPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/ClientboundMapItemDataPacket.java
@@ -2,7 +2,7 @@ package cn.nukkit.network.protocol;
 
 import cn.nukkit.utils.Utils;
 
-import java.awt.*;
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 
 /**

--- a/src/main/java/cn/nukkit/utils/BlockColor.java
+++ b/src/main/java/cn/nukkit/utils/BlockColor.java
@@ -4,7 +4,7 @@ package cn.nukkit.utils;
  * Created by Snake1999 on 2016/1/10.
  * Package cn.nukkit.utils in project nukkit
  */
-public class BlockColor extends java.awt.Color {
+public class BlockColor  {
 
     public static final BlockColor TRANSPARENT_BLOCK_COLOR = new BlockColor(0x00, 0x00, 0x00, 0x00);
     public static final BlockColor VOID_BLOCK_COLOR = new BlockColor(0x00, 0x00, 0x00, 0x00);
@@ -52,28 +52,62 @@ public class BlockColor extends java.awt.Color {
     public static final BlockColor NETHERRACK_BLOCK_COLOR = new BlockColor(0x70, 0x02, 0x00);
     public static final BlockColor REDSTONE_BLOCK_COLOR = TNT_BLOCK_COLOR;
 
-    public BlockColor(float r, float g, float b, float a) {
-        super(r, g, b, a);
+    private int red;
+    private int green;
+    private int blue;
+    private int alpha;
+
+    public BlockColor(int red, int green, int blue, int alpha) {
+        this.red = red;
+        this.green = green;
+        this.blue = blue;
+        this.alpha = alpha;
     }
 
-    public BlockColor(float r, float g, float b) {
-        super(r, g, b);
-    }
-
-    public BlockColor(int rgba, boolean hasAlpha) {
-        super(rgba, hasAlpha);
-    }
-
-    public BlockColor(int r, int g, int b, int a) {
-        super(r, g, b, a);
+    public BlockColor(int red, int green, int blue) {
+        this(red, green, blue, 0xff);
     }
 
     public BlockColor(int rgb) {
-        super(rgb);
+        this.red = (rgb >> 16) & 0xff;
+        this.green = (rgb >> 8) & 0xff;
+        this.blue = (rgb >> 0) & 0xff;
+        this.alpha = 0xff;
     }
 
-    public BlockColor(int r, int g, int b) {
-        super(r, g, b);
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof BlockColor)) {
+            return false;
+        }
+        BlockColor other = (BlockColor) obj;
+        return this.red == other.red && this.green == other.green &&
+                this.blue == other.blue && this.alpha == other.alpha;
+    }
+
+    @Override
+    public String toString() {
+        return "BlockColor[r=" + this.red + ",g=" + this.green + ",b=" + this.blue + ",a=" + this.alpha + "]";
+    }
+
+    public int getRed() {
+        return this.red;
+    }
+
+    public int getGreen() {
+        return this.green;
+    }
+
+    public int getBlue() {
+        return this.blue;
+    }
+
+    public int getAlpha() {
+        return this.alpha;
+    }
+
+    public int getRGB() {
+        return (this.red << 16 | this.green << 8 | this.blue) & 0xffffff;
     }
 
     @Deprecated

--- a/src/main/java/cn/nukkit/utils/DummyBossBar.java
+++ b/src/main/java/cn/nukkit/utils/DummyBossBar.java
@@ -7,7 +7,6 @@ import cn.nukkit.entity.data.EntityMetadata;
 import cn.nukkit.entity.mob.EntityCreeper;
 import cn.nukkit.network.protocol.*;
 
-import java.awt.*;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -24,7 +23,7 @@ public class DummyBossBar {
 
     private String text;
     private float length;
-    private Color color;
+    private BlockColor color;
 
     private DummyBossBar(Builder builder) {
         this.player = builder.player;
@@ -40,7 +39,7 @@ public class DummyBossBar {
 
         private String text = "";
         private float length = 100;
-        private Color color = null;
+        private BlockColor color = null;
 
         public Builder(Player player) {
             this.player = player;
@@ -57,13 +56,13 @@ public class DummyBossBar {
             return this;
         }
 
-        public Builder color(Color color) {
+        public Builder color(BlockColor color) {
             this.color = color;
             return this;
         }
 
         public Builder color(int red, int green, int blue) {
-            return color(new Color(red, green, blue));
+            return color(new BlockColor(red, green, blue));
         }
 
         public DummyBossBar build() {
@@ -106,7 +105,7 @@ public class DummyBossBar {
      * Color is not working in the current version. We are keep waiting for client support.
      * @param color the boss bar color
      */
-    public void setColor(Color color) {
+    public void setColor(BlockColor color) {
         if (this.color == null || !this.color.equals(color)) {
             this.color = color;
             this.sendSetBossBarTexture();
@@ -114,14 +113,14 @@ public class DummyBossBar {
     }
 
     public void setColor(int red, int green, int blue) {
-        this.setColor(new Color(red, green, blue));
+        this.setColor(new BlockColor(red, green, blue));
     }
 
     public int getMixedColor() {
         return this.color.getRGB();//(this.color.getRed() << 16 | this.color.getGreen() << 8 | this.color.getBlue()) & 0xffffff;
     }
 
-    public Color getColor() {
+    public BlockColor getColor() {
         return this.color;
     }
 


### PR DESCRIPTION
Some core classes in Nukkit were dependent on some simple AWT classes (typically Color). Since AWT is a desktop technology, this caused an AWT-AppKit window to appear on macOS when running Nukkit. This is unfortunate, since Nukkit is (or should be) a pure server that should run without creating GUI artifacts. :-(

I've minimized the dependency on AWT classes in this patch. There are some cases left which still use AWT (e.g. BufferedImage), but that part of AWT is due to move out of the java.desktop module in a future release of Java.


I have verified that this patch inhibits the AWT-AppKit window to appear for normal usage. I have not been able to test the Skin code with BufferedImage, since I frankly do not know how to set a Skin in the MC client.