### PR TITLE
fixed extremely stupid bug with player spawns

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -1904,7 +1904,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         Level level;
         if ((level = this.server.getLevelByName(nbt.getString("Level"))) == null || !alive) {
             this.setLevel(this.server.getDefaultLevel());
-            nbt.putString("Level", this.level.getName());
+            nbt.putString("Level", this.level.getFolderName());
             nbt.getList("Pos", DoubleTag.class)
                     .add(new DoubleTag("0", this.level.getSpawnLocation().x))
                     .add(new DoubleTag("1", this.level.getSpawnLocation().y))

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -1483,7 +1483,7 @@ public class Server {
                         .add(new DoubleTag("0", spawn.x))
                         .add(new DoubleTag("1", spawn.y))
                         .add(new DoubleTag("2", spawn.z)))
-                .putString("Level", this.getDefaultLevel().getName())
+                .putString("Level", this.getDefaultLevel().getFolderName())
                 .putList(new ListTag<>("Inventory"))
                 .putCompound("Achievements", new CompoundTag())
                 .putInt("playerGameType", this.getGamemode())


### PR DESCRIPTION
This was causing new players to inexplicably spawn in the wrong place when joining a world for the first time which had a different level name than folder name. With LevelDB worlds, this caused them to spawn wayyyy up at y=32767 for no good reason.



*I have this issue and i know exist in nukkit.*