### PR TITLE
Fix bubbles showing under water in creative (#31).

### DIFF
--- a/src/main/java/cn/nukkit/entity/EntityLiving.java
+++ b/src/main/java/cn/nukkit/entity/EntityLiving.java
@@ -192,7 +192,11 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
     @Override
     public boolean entityBaseTick(int tickDiff) {
         Timings.livingEntityBaseTickTimer.startTiming();
-        this.setDataFlag(DATA_FLAGS, DATA_FLAG_BREATHING, !this.isInsideOfWater());
+        boolean isBreathing = !this.isInsideOfWater();
+        if (this instanceof Player && ((Player) this).isCreative()) {
+            isBreathing = true;
+        }
+        this.setDataFlag(DATA_FLAGS, DATA_FLAG_BREATHING, isBreathing);
 
         boolean hasUpdate = super.entityBaseTick(tickDiff);
 


### PR DESCRIPTION
Always set players in creative mode as breathing. 

This fixes https://github.com/NukkitX/Nukkit/issues/31.