### PR TITLE
Fix race condition in MainLogger.

### DIFF
--- a/src/main/java/cn/nukkit/Nukkit.java
+++ b/src/main/java/cn/nukkit/Nukkit.java
@@ -123,7 +123,6 @@ public class Nukkit {
         killer.start();
 
         logger.shutdown();
-        logger.interrupt();
         CommandReader.getInstance().removePromptLine();
 
         if (ANSI) {

--- a/src/main/java/cn/nukkit/utils/MainLogger.java
+++ b/src/main/java/cn/nukkit/utils/MainLogger.java
@@ -21,12 +21,14 @@ public class MainLogger extends ThreadedLogger {
 
     protected final String logPath;
     protected final ConcurrentLinkedQueue<String> logBuffer = new ConcurrentLinkedQueue<>();
-    protected boolean shutdown;
+    protected boolean shutdown = false;
+    private boolean isShutdown = false;
     protected LogLevel logLevel = LogLevel.DEFAULT_LEVEL;
     private final Map<TextFormat, String> replacements = new EnumMap<>(TextFormat.class);
     private final TextFormat[] colors = TextFormat.values();
 
     protected static MainLogger logger;
+    private File logFile;
 
     public MainLogger(String logFile) {
         this(logFile, LogLevel.DEFAULT_LEVEL);
@@ -39,6 +41,8 @@ public class MainLogger extends ThreadedLogger {
         }
         logger = this;
         this.logPath = logFile;
+        this.setName("Logger");
+        this.initialize();
         this.start();
     }
 
@@ -137,7 +141,18 @@ public class MainLogger extends ThreadedLogger {
     }
 
     public void shutdown() {
-        this.shutdown = true;
+        synchronized (this) {
+            this.shutdown = true;
+            this.interrupt();
+            while (!this.isShutdown) {
+                try {
+                    wait(1000);
+                } catch (InterruptedException e) {
+                    // Ignore exception and treat it as we're done
+                    return;
+                }
+            }
+        }
     }
 
     protected void send(String message) {
@@ -171,8 +186,21 @@ public class MainLogger extends ThreadedLogger {
 
     @Override
     public void run() {
+        do {
+            waitForMessage();
+            flushBuffer(logFile);
+        } while (!this.shutdown);
+
+        flushBuffer(logFile);
+        synchronized (this) {
+            this.isShutdown = true;
+            this.notify();
+        }
+    }
+
+    private void initialize() {
         AnsiConsole.systemInstall();
-        File logFile = new File(logPath);
+        logFile = new File(logPath);
         if (!logFile.exists()) {
             try {
                 logFile.createNewFile();
@@ -217,14 +245,9 @@ public class MainLogger extends ThreadedLogger {
         replacements.put(TextFormat.UNDERLINE, Ansi.ansi().a(Ansi.Attribute.UNDERLINE).toString());
         replacements.put(TextFormat.ITALIC, Ansi.ansi().a(Ansi.Attribute.ITALIC).toString());
         replacements.put(TextFormat.RESET, Ansi.ansi().a(Ansi.Attribute.RESET).toString());
-        this.shutdown = false;
-        do {
-            flushBuffer(logFile);
-        } while (!this.shutdown);
-        flushBuffer(logFile);
     }
 
-    private void flushBuffer(File logFile) {
+    private void waitForMessage() {
         if (logBuffer.isEmpty()) {
             try {
                 synchronized (this) {
@@ -234,6 +257,9 @@ public class MainLogger extends ThreadedLogger {
             } catch (InterruptedException ignore) {
             }
         }
+    }
+
+    private void flushBuffer(File logFile) {
         try {
             Writer writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(logFile, true), StandardCharsets.UTF_8), 1024);
             Date now = new Date();


### PR DESCRIPTION
There's a race condition in the logger class. If the server quits very quickly after startup on an error condition (typically an issue that can happen on incorrect configuration) the logger thread might not have time to print any buffered logs, and no output is written, which severely limits the possibilities to figure out the errors of said configuration. :-(

This patch addresses this issue by moving initialization code to the main thread instead of the logger thread to ensure that the worker thread can start working immediately, breaking out the waiting part of flushBuffer() so it's not done after the shutdown signal is received, and introducing a back-signalling mechanism from the worker thread to confirm to the main thread shutdown() method that it is indeed done.