### PR TITLE
Optimize block updates 1/3

### DIFF
--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -983,14 +983,25 @@ public abstract class Block extends Position implements Metadatable, Cloneable, 
     }
 
     public Block getSide(BlockFace face) {
+        if (this.isValid()) {
+            return this.getLevel().getBlock((int) x + face.getXOffset(), (int) y + face.getYOffset(), (int) z + face.getZOffset());
+        }
         return this.getSide(face, 1);
     }
 
     public Block getSide(BlockFace face, int step) {
         if (this.isValid()) {
-            return this.getLevel().getBlock(super.getSide(face, step));
+            if (step == 1) {
+                return this.getLevel().getBlock((int) x + face.getXOffset(), (int) y + face.getYOffset(), (int) z + face.getZOffset());
+            } else {
+                return this.getLevel().getBlock((int) x + face.getXOffset() * step, (int) y + face.getYOffset() * step, (int) z + face.getZOffset() * step);
+            }
         }
-        return Block.get(Item.AIR, 0, Position.fromObject(new Vector3(this.x, this.y, this.z).getSide(face, step)));
+        Block block = Block.get(Item.AIR, 0);
+        block.x = (int) x + face.getXOffset() * step;
+        block.y = (int) y + face.getYOffset() * step;
+        block.z = (int) z + face.getZOffset() * step;
+        return block;
     }
 
     public Block up() {

--- a/src/main/java/cn/nukkit/block/BlockLeaves.java
+++ b/src/main/java/cn/nukkit/block/BlockLeaves.java
@@ -10,8 +10,9 @@ import cn.nukkit.item.ItemTool;
 import cn.nukkit.level.Level;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.utils.BlockColor;
-
-import java.util.ArrayList;
+import cn.nukkit.utils.Hash;
+import it.unimi.dsi.fastutil.longs.LongArraySet;
+import it.unimi.dsi.fastutil.longs.LongSet;
 
 /**
  * author: Angelic47
@@ -110,13 +111,12 @@ public class BlockLeaves extends BlockTransparentMeta {
         } else if (type == Level.BLOCK_UPDATE_RANDOM) {
             if ((getDamage() & 0b00001100) == 0x08) {
                 setDamage(getDamage() & 0x03);
-                ArrayList<String> visited = new ArrayList<>();
                 int check = 0;
 
                 LeavesDecayEvent ev = new LeavesDecayEvent(this);
 
                 Server.getInstance().getPluginManager().callEvent(ev);
-                if (ev.isCancelled() || findLog(this, visited, 0, check)) {
+                if (ev.isCancelled() || findLog(this, new LongArraySet(), 0, check)) {
                     getLevel().setBlock(this, this, false, false);
                 } else {
                     getLevel().useBreakOn(this);
@@ -127,13 +127,13 @@ public class BlockLeaves extends BlockTransparentMeta {
         return 0;
     }
 
-    private Boolean findLog(Block pos, ArrayList<String> visited, Integer distance, Integer check) {
+    private Boolean findLog(Block pos, LongSet visited, Integer distance, Integer check) {
         return findLog(pos, visited, distance, check, null);
     }
 
-    private Boolean findLog(Block pos, ArrayList<String> visited, Integer distance, Integer check, BlockFace fromSide) {
+    private Boolean findLog(Block pos, LongSet visited, Integer distance, Integer check, BlockFace fromSide) {
         ++check;
-        String index = pos.x + "." + pos.y + "." + pos.z;
+        long index = Hash.hashBlock((int) pos.x, (int) pos.y, (int) pos.z);
         if (visited.contains(index)) return false;
         if (pos.getId() == Block.WOOD) return true;
         if (pos.getId() == Block.LEAVES && distance < 4) {

--- a/src/main/java/cn/nukkit/level/Explosion.java
+++ b/src/main/java/cn/nukkit/level/Explosion.java
@@ -15,9 +15,9 @@ import cn.nukkit.item.ItemBlock;
 import cn.nukkit.level.particle.HugeExplodeSeedParticle;
 import cn.nukkit.math.*;
 import cn.nukkit.network.protocol.ExplodePacket;
-
+import cn.nukkit.utils.Hash;
+import it.unimi.dsi.fastutil.longs.LongArraySet;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -112,7 +112,7 @@ public class Explosion {
 
     public boolean explodeB() {
 
-        HashMap<BlockVector3, Boolean> updateBlocks = new HashMap<>();
+        LongArraySet updateBlocks = new LongArraySet();
         List<Vector3> send = new ArrayList<>();
 
         Vector3 source = (new Vector3(this.source.x, this.source.y, this.source.z)).floor();
@@ -180,14 +180,14 @@ public class Explosion {
 
             for (BlockFace side : BlockFace.values()) {
                 Vector3 sideBlock = pos.getSide(side);
-                BlockVector3 index = Level.blockHash((int) sideBlock.x, (int) sideBlock.y, (int) sideBlock.z);
-                if (!this.affectedBlocks.contains(sideBlock) && !updateBlocks.containsKey(index)) {
+                long index = Hash.hashBlock((int) sideBlock.x, (int) sideBlock.y, (int) sideBlock.z);
+                if (!this.affectedBlocks.contains(sideBlock) && !updateBlocks.contains(index)) {
                     BlockUpdateEvent ev = new BlockUpdateEvent(this.level.getBlock(sideBlock));
                     this.level.getServer().getPluginManager().callEvent(ev);
                     if (!ev.isCancelled()) {
                         ev.getBlock().onUpdate(Level.BLOCK_UPDATE_NORMAL);
                     }
-                    updateBlocks.put(index, true);
+                    updateBlocks.add(index);
                 }
             }
             send.add(new Vector3(block.x - source.x, block.y - source.y, block.z - source.z));

--- a/src/main/java/cn/nukkit/utils/Hash.java
+++ b/src/main/java/cn/nukkit/utils/Hash.java
@@ -1,0 +1,20 @@
+package cn.nukkit.utils;
+
+public class Hash {
+    public static long hashBlock(int x, int y, int z) {
+        return y + (((long) x & 0x3FFFFFF) << 8) + (((long) z & 0x3FFFFFF) << 34);
+    }
+
+
+    public static final int hashBlockX(long triple) {
+        return (int) ((((triple >> 8) & 0x3FFFFFF) << 38) >> 38);
+    }
+
+    public static final int hashBlockY(long triple) {
+        return (int) (triple & 0xFF);
+    }
+
+    public static final int hashBlockZ(long triple) {
+        return (int) ((((triple >> 34) & 0x3FFFFFF) << 38) >> 38);
+    }
+}


### PR DESCRIPTION
Reduce Position object creation by using primitive x,y,z for coordinates
Reduce BlockVector3 creation by using long as block hash
Oh gosh, it's still using a string for a block coordinate in BlockLeaves; kill me now.