### PR TITLE
Improved error message in case language files are missing.

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -248,7 +248,11 @@ public class Server {
         if (!new File(this.dataPath + "nukkit.yml").exists()) {
             this.getLogger().info(TextFormat.GREEN + "Welcome! Please choose a language first!");
             try {
-                String[] lines = Utils.readFile(this.getClass().getClassLoader().getResourceAsStream("lang/language.list")).split("\n");
+                InputStream languageList = this.getClass().getClassLoader().getResourceAsStream("lang/language.list");
+                if (languageList == null) {
+                    throw new RuntimeException("lang/language.list is missing. If you are running a development version, make sure you have run 'git submodule update --init'.");
+                }
+                String[] lines = Utils.readFile(languageList).split("\n");
                 for (String line : lines) {
                     this.getLogger().info(line);
                 }


### PR DESCRIPTION
A typical stumble-block for initial deployment of a git cloned version of Nukkit is forgetting the translation submodule. 

Yes, I know it is in the README. It's still easy to forgot; I've done it twice on different machines and ran into it a third time helping another developer set up Nukkit development.

This is a trivial change that will output a more suitable error message in case this has happened. The likelihood that the language files has disappeared in all other cases is rather slim.