### PR TITLE
optimize timings when not running

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -1025,7 +1025,6 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
             DataPacketSendEvent event = new DataPacketSendEvent(this, packet);
             this.server.getPluginManager().callEvent(event);
             if (event.isCancelled()) {
-                timing.stopTiming();
                 return false;
             }
 
@@ -1056,7 +1055,6 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
             DataPacketSendEvent ev = new DataPacketSendEvent(this, packet);
             this.server.getPluginManager().callEvent(ev);
             if (ev.isCancelled()) {
-                timing.stopTiming();
                 return -1;
             }
 
@@ -1064,7 +1062,6 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
             if (needACK && identifier != null) {
                 this.needACK.put(identifier, Boolean.FALSE);
-                timing.stopTiming();
                 return identifier;
             }
         }
@@ -1089,7 +1086,6 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
             DataPacketSendEvent ev = new DataPacketSendEvent(this, packet);
             this.server.getPluginManager().callEvent(ev);
             if (ev.isCancelled()) {
-                timing.stopTiming();
                 return -1;
             }
 
@@ -1097,7 +1093,6 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
             if (needACK && identifier != null) {
                 this.needACK.put(identifier, Boolean.FALSE);
-                timing.stopTiming();
                 return identifier;
             }
         }
@@ -2036,12 +2031,10 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
             DataPacketReceiveEvent ev = new DataPacketReceiveEvent(this, packet);
             this.server.getPluginManager().callEvent(ev);
             if (ev.isCancelled()) {
-                timing.stopTiming();
                 return;
             }
 
             if (packet.pid() == ProtocolInfo.BATCH_PACKET) {
-                timing.stopTiming();
                 this.server.getNetwork().processBatch((BatchPacket) packet, this);
                 return;
             }

--- a/src/main/java/co/aikar/timings/Timings.java
+++ b/src/main/java/co/aikar/timings/Timings.java
@@ -35,12 +35,12 @@ import cn.nukkit.plugin.MethodEventExecutor;
 import cn.nukkit.plugin.Plugin;
 import cn.nukkit.scheduler.PluginTask;
 import cn.nukkit.scheduler.TaskHandler;
-
-import static co.aikar.timings.TimingIdentifier.DEFAULT_GROUP;
-
 import java.util.HashSet;
 import java.util.Queue;
 import java.util.Set;
+
+
+import static co.aikar.timings.TimingIdentifier.DEFAULT_GROUP;
 
 public final class Timings {
     private static boolean timingsEnabled = false;
@@ -204,10 +204,12 @@ public final class Timings {
 
 
     public static Timing getCommandTiming(Command command) {
+        if (!isTimingsEnabled()) return commandTimer;
         return TimingsManager.getTiming(DEFAULT_GROUP.name, "Command: " + command.getLabel(), commandTimer);
     }
 
     public static Timing getTaskTiming(TaskHandler handler, long period) {
+        if (!isTimingsEnabled()) return schedulerSyncTimer;
         String repeating = " ";
         if (period > 0) {
             repeating += "(interval:" + period + ")";
@@ -226,6 +228,7 @@ public final class Timings {
     }
 
     public static Timing getPluginEventTiming(Class<? extends Event> event, Listener listener, EventExecutor executor, Plugin plugin) {
+        if (!isTimingsEnabled()) return pluginEventTimer;
         Timing group = TimingsManager.getTiming(plugin.getName(), "Combined Total", pluginEventTimer);
 
         return TimingsManager.getTiming(plugin.getName(), "Event: " + listener.getClass().getName() + "."
@@ -234,18 +237,22 @@ public final class Timings {
     }
 
     public static Timing getEntityTiming(Entity entity) {
+        if (!isTimingsEnabled()) return tickEntityTimer;
         return TimingsManager.getTiming(DEFAULT_GROUP.name, "## Entity Tick: " + entity.getClass().getSimpleName(), tickEntityTimer);
     }
 
     public static Timing getBlockEntityTiming(BlockEntity blockEntity) {
+        if (!isTimingsEnabled()) return tickBlockEntityTimer;
         return TimingsManager.getTiming(DEFAULT_GROUP.name, "## BlockEntity Tick: " + blockEntity.getClass().getSimpleName(), tickBlockEntityTimer);
     }
 
     public static Timing getReceiveDataPacketTiming(DataPacket pk) {
+        if (!isTimingsEnabled()) return playerNetworkReceiveTimer;
         return TimingsManager.getTiming(DEFAULT_GROUP.name, "## Receive Packet: " + pk.getClass().getSimpleName(), playerNetworkReceiveTimer);
     }
 
     public static Timing getSendDataPacketTiming(DataPacket pk) {
+        if (!isTimingsEnabled()) return playerNetworkSendTimer;
         return TimingsManager.getTiming(DEFAULT_GROUP.name, "## Send Packet: " + pk.getClass().getSimpleName(), playerNetworkSendTimer);
     }
 


### PR DESCRIPTION
The timings system does a bunch of string concatenation / creating new timing objects even when it is disabled. It shouldn't do that. 