### PR TITLE
Direct async chunk modification with generator/populator

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -216,7 +216,7 @@ public class Server {
 
     private Level defaultLevel = null;
 
-    private Thread currentThread;
+    private final Thread currentThread;
 
     private Watchdog watchdog;
 
@@ -1992,7 +1992,7 @@ public class Server {
      * @return true if the current thread matches the expected primary thread,
      * false otherwise
      */
-    public boolean isPrimaryThread() {
+    public final boolean isPrimaryThread() {
         return (Thread.currentThread() == currentThread);
     }
 

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -2357,44 +2357,47 @@ public class Level implements ChunkManager, Metadatable {
 
         long index = Level.chunkHash(chunkX, chunkZ);
         FullChunk oldChunk = this.getChunk(chunkX, chunkZ, false);
-        if (unload && oldChunk != null) {
-            this.unloadChunk(chunkX, chunkZ, false, false);
 
-            this.provider.setChunk(chunkX, chunkZ, chunk);
-        } else {
-            Map<Long, Entity> oldEntities = oldChunk != null ? oldChunk.getEntities() : Collections.emptyMap();
+        if (oldChunk != chunk) {
+            if (unload && oldChunk != null) {
+                this.unloadChunk(chunkX, chunkZ, false, false);
 
-            Map<Long, BlockEntity> oldBlockEntities = oldChunk != null ? oldChunk.getBlockEntities() : Collections.emptyMap();
+                this.provider.setChunk(chunkX, chunkZ, chunk);
+            } else {
+                Map<Long, Entity> oldEntities = oldChunk != null ? oldChunk.getEntities() : Collections.emptyMap();
 
-            if (!oldEntities.isEmpty()) {
-                Iterator<Map.Entry<Long, Entity>> iter = oldEntities.entrySet().iterator();
-                while (iter.hasNext()) {
-                    Map.Entry<Long, Entity> entry = iter.next();
-                    Entity entity = entry.getValue();
-                    chunk.addEntity(entity);
-                    if (oldChunk != null) {
-                        iter.remove();
-                        oldChunk.removeEntity(entity);
-                        entity.chunk = chunk;
+                Map<Long, BlockEntity> oldBlockEntities = oldChunk != null ? oldChunk.getBlockEntities() : Collections.emptyMap();
+
+                if (!oldEntities.isEmpty()) {
+                    Iterator<Map.Entry<Long, Entity>> iter = oldEntities.entrySet().iterator();
+                    while (iter.hasNext()) {
+                        Map.Entry<Long, Entity> entry = iter.next();
+                        Entity entity = entry.getValue();
+                        chunk.addEntity(entity);
+                        if (oldChunk != null) {
+                            iter.remove();
+                            oldChunk.removeEntity(entity);
+                            entity.chunk = chunk;
+                        }
                     }
                 }
-            }
 
-            if (!oldBlockEntities.isEmpty()) {
-                Iterator<Map.Entry<Long, BlockEntity>> iter = oldBlockEntities.entrySet().iterator();
-                while (iter.hasNext()) {
-                    Map.Entry<Long, BlockEntity> entry = iter.next();
-                    BlockEntity blockEntity = entry.getValue();
-                    chunk.addBlockEntity(blockEntity);
-                    if (oldChunk != null) {
-                        iter.remove();
-                        oldChunk.removeBlockEntity(blockEntity);
-                        blockEntity.chunk = chunk;
+                if (!oldBlockEntities.isEmpty()) {
+                    Iterator<Map.Entry<Long, BlockEntity>> iter = oldBlockEntities.entrySet().iterator();
+                    while (iter.hasNext()) {
+                        Map.Entry<Long, BlockEntity> entry = iter.next();
+                        BlockEntity blockEntity = entry.getValue();
+                        chunk.addBlockEntity(blockEntity);
+                        if (oldChunk != null) {
+                            iter.remove();
+                            oldChunk.removeBlockEntity(blockEntity);
+                            blockEntity.chunk = chunk;
+                        }
                     }
                 }
-            }
 
-            this.provider.setChunk(chunkX, chunkZ, chunk);
+                this.provider.setChunk(chunkX, chunkZ, chunk);
+            }
         }
 
         chunk.setChanged();

--- a/src/main/java/cn/nukkit/level/format/anvil/Chunk.java
+++ b/src/main/java/cn/nukkit/level/format/anvil/Chunk.java
@@ -485,7 +485,7 @@ public class Chunk extends BaseChunk {
 
             chunk.setPosition(chunkX, chunkZ);
 
-            chunk.heightMap = ThreadCache.byteCache256.get();
+            chunk.heightMap = new byte[256];
             chunk.inhabitedTime = 0;
             chunk.terrainGenerated = false;
             chunk.terrainPopulated = false;

--- a/src/main/java/cn/nukkit/level/format/anvil/palette/BiomePalette.java
+++ b/src/main/java/cn/nukkit/level/format/anvil/palette/BiomePalette.java
@@ -31,7 +31,7 @@ public final class BiomePalette {
         return get(getIndex(x, z));
     }
 
-    public int get(int index) {
+    public synchronized int get(int index) {
         if (encodedData == null) return biome;
         return palette.getKey(encodedData.getAt(index));
     }
@@ -40,7 +40,7 @@ public final class BiomePalette {
         set(getIndex(x, z), value);
     }
 
-    public void set(int index, int value) {
+    public synchronized void set(int index, int value) {
         if (encodedData == null) {
             if (value == biome) return;
             if (biome == Integer.MIN_VALUE) {
@@ -98,7 +98,7 @@ public final class BiomePalette {
 
     }
 
-    public int[] toRaw() {
+    public synchronized int[] toRaw() {
         int[] buffer = ThreadCache.intCache256.get();
         if (encodedData == null) {
             Arrays.fill(buffer, biome);

--- a/src/main/java/cn/nukkit/level/format/anvil/palette/BlockDataPalette.java
+++ b/src/main/java/cn/nukkit/level/format/anvil/palette/BlockDataPalette.java
@@ -1,8 +1,6 @@
 package cn.nukkit.level.format.anvil.palette;
 
-import cn.nukkit.math.MathHelper;
-import cn.nukkit.utils.ThreadCache;
-import java.util.Arrays;
+import cn.nukkit.Server;
 
 /**
  * @author https://github.com/boy0001/
@@ -22,6 +20,15 @@ public final class BlockDataPalette implements Cloneable {
 
     public BlockDataPalette(char[] rawData) {
         this.rawData = rawData;
+    }
+
+    private char[] getCachedRaw() {
+        char[] raw = rawData;
+        if (raw != null) return raw;
+        else if (!Server.getInstance().isPrimaryThread()) {
+            return getRaw();
+        }
+        return rawData;
     }
 
     public synchronized char[] getRaw() {
@@ -56,14 +63,22 @@ public final class BlockDataPalette implements Cloneable {
 
     public void setBlockData(int x, int y, int z, int data) {
         int index = getIndex(x, y, z);
-        char[] raw = rawData;
+        char[] raw = getCachedRaw();
         if (raw != null) {
             int fullId = raw[index];
             raw[index] = (char) ((fullId & 0xFFF0) | data);
         } else {
-            char fullId = palette.getKey(encodedData.getAt(index));
-            if ((fullId & 0xF) != data) {
-                setPaletteFullBlock(index, (char) ((fullId & 0xFFF0) | data));
+            CharPalette palette = this.palette;
+            BitArray4096 encodedData = this.encodedData;
+            if (palette != null && encodedData != null) {
+                char fullId = palette.getKey(encodedData.getAt(index));
+                if ((fullId & 0xF) != data) {
+                    setPaletteFullBlock(index, (char) ((fullId & 0xFFF0) | data));
+                }
+            } else {
+                synchronized (this) {
+                    setBlockData(x, y, z, data);
+                }
             }
         }
 
@@ -82,30 +97,46 @@ public final class BlockDataPalette implements Cloneable {
     }
 
     private int getAndSetFullBlock(int index, char value) {
-        char[] raw = rawData;
+        char[] raw = getCachedRaw();
         if (raw != null) {
             char result = raw[index];
             raw[index] = value;
             return result;
         } else {
-            char fullId = palette.getKey(encodedData.getAt(index));
-            if (fullId != value) {
-                setPaletteFullBlock(index, value);
+            CharPalette palette = this.palette;
+            BitArray4096 encodedData = this.encodedData;
+            if (palette != null && encodedData != null) {
+                char fullId = palette.getKey(encodedData.getAt(index));
+                if (fullId != value) {
+                    setPaletteFullBlock(index, value);
+                }
+                return fullId;
+            } else {
+                synchronized (this) {
+                    return getAndSetFullBlock(index, value);
+                }
             }
-            return fullId;
         }
     }
 
     private int getFullBlock(int index) {
-        char[] raw = rawData;
+        char[] raw = getCachedRaw();
         if (raw != null) {
             return raw[index];
         }
-        return palette.getKey(encodedData.getAt(index));
+        CharPalette palette = this.palette;
+        BitArray4096 encodedData = this.encodedData;
+        if (palette != null && encodedData != null) {
+            return palette.getKey(encodedData.getAt(index));
+        } else {
+            synchronized (this) {
+                return getFullBlock(index);
+            }
+        }
     }
 
     private void setFullBlock(int index, char value) {
-        char[] raw = rawData;
+        char[] raw = getCachedRaw();
         if (raw != null) {
             raw[index] = value;
             return;
@@ -114,19 +145,27 @@ public final class BlockDataPalette implements Cloneable {
     }
 
     private void setPaletteFullBlock(int index, char value) {
-        char encodedValue = palette.getValue(value);
-        if (encodedValue != Character.MAX_VALUE) {
-            encodedData.setAt(index, encodedValue);
+        CharPalette palette = this.palette;
+        BitArray4096 encodedData = this.encodedData;
+        if (palette != null && encodedData != null) {
+            char encodedValue = palette.getValue(value);
+            if (encodedValue != Character.MAX_VALUE) {
+                encodedData.setAt(index, encodedValue);
+            } else {
+                synchronized (this) {
+                    char[] raw = encodedData.toRaw();
+                    for (int i = 0; i < 4096; i++) {
+                        raw[i] = palette.getKey(raw[i]);
+                    }
+                    raw[index] = value;
+                    this.rawData = raw;
+                    this.encodedData = null;
+                    this.palette = null;
+                }
+            }
         } else {
             synchronized (this) {
-                char[] raw = encodedData.toRaw();
-                for (int i = 0; i < 4096; i++) {
-                    raw[i] = palette.getKey(raw[i]);
-                }
-                raw[index] = value;
-                rawData = raw;
-                encodedData = null;
-                palette = null;
+                setFullBlock(index, value);
             }
         }
     }
@@ -135,46 +174,46 @@ public final class BlockDataPalette implements Cloneable {
         char[] raw = rawData;
         if (raw != null) {
             synchronized (this) {
-                char unique = 0;
-
-                boolean[] countTable = ThreadCache.boolCache4096.get();
-                char[] mapFullTable = ThreadCache.charCache4096.get();
-                char[] mapBitTable = ThreadCache.charCache4096v2.get();
-                Arrays.fill(countTable, false);
-                for (char c : raw) {
-                    if (!countTable[c]) {
-                        mapBitTable[unique] = c;
-                        countTable[c] = true;
-                        unique++;
-                    }
-                }
-
-                char[] keys = Arrays.copyOfRange(mapBitTable, 0, unique);
-                if (keys.length > 1) {
-                    Arrays.sort(keys);
-                    for (char c = 0; c < keys.length; c++) {
-                        mapFullTable[keys[c]] = c;
-                    }
-                } else {
-                    mapFullTable[keys[0]] = 0;
-                }
-
-                CharPalette palette = new CharPalette();
-                palette.set(keys);
-
-                int bits = MathHelper.log2(unique - 1);
-                BitArray4096 encodedData = new BitArray4096(bits);
-
-                for (int i = 0; i < raw.length; i++) {
-                    mapBitTable[i] = mapFullTable[raw[i]];
-                }
-
-                encodedData.fromRaw(mapBitTable);
-
-                this.palette = palette;
-                this.encodedData = encodedData;
-                rawData = null;
-                return true;
+//                char unique = 0;
+//
+//                boolean[] countTable = ThreadCache.boolCache4096.get();
+//                char[] mapFullTable = ThreadCache.charCache4096.get();
+//                char[] mapBitTable = ThreadCache.charCache4096v2.get();
+//                Arrays.fill(countTable, false);
+//                for (char c : raw) {
+//                    if (!countTable[c]) {
+//                        mapBitTable[unique] = c;
+//                        countTable[c] = true;
+//                        unique++;
+//                    }
+//                }
+//
+//                char[] keys = Arrays.copyOfRange(mapBitTable, 0, unique);
+//                if (keys.length > 1) {
+//                    Arrays.sort(keys);
+//                    for (char c = 0; c < keys.length; c++) {
+//                        mapFullTable[keys[c]] = c;
+//                    }
+//                } else {
+//                    mapFullTable[keys[0]] = 0;
+//                }
+//
+//                CharPalette palette = new CharPalette();
+//                palette.set(keys);
+//
+//                int bits = MathHelper.log2(unique - 1);
+//                BitArray4096 encodedData = new BitArray4096(bits);
+//
+//                for (int i = 0; i < raw.length; i++) {
+//                    mapBitTable[i] = mapFullTable[raw[i]];
+//                }
+//
+//                encodedData.fromRaw(mapBitTable);
+//
+//                this.palette = palette;
+//                this.encodedData = encodedData;
+//                rawData = null;
+//                return true;
             }
         }
         return false;

--- a/src/main/java/cn/nukkit/level/format/anvil/palette/BlockDataPalette.java
+++ b/src/main/java/cn/nukkit/level/format/anvil/palette/BlockDataPalette.java
@@ -1,6 +1,9 @@
 package cn.nukkit.level.format.anvil.palette;
 
 import cn.nukkit.Server;
+import cn.nukkit.math.MathHelper;
+import cn.nukkit.utils.ThreadCache;
+import java.util.Arrays;
 
 /**
  * @author https://github.com/boy0001/
@@ -174,46 +177,46 @@ public final class BlockDataPalette implements Cloneable {
         char[] raw = rawData;
         if (raw != null) {
             synchronized (this) {
-//                char unique = 0;
-//
-//                boolean[] countTable = ThreadCache.boolCache4096.get();
-//                char[] mapFullTable = ThreadCache.charCache4096.get();
-//                char[] mapBitTable = ThreadCache.charCache4096v2.get();
-//                Arrays.fill(countTable, false);
-//                for (char c : raw) {
-//                    if (!countTable[c]) {
-//                        mapBitTable[unique] = c;
-//                        countTable[c] = true;
-//                        unique++;
-//                    }
-//                }
-//
-//                char[] keys = Arrays.copyOfRange(mapBitTable, 0, unique);
-//                if (keys.length > 1) {
-//                    Arrays.sort(keys);
-//                    for (char c = 0; c < keys.length; c++) {
-//                        mapFullTable[keys[c]] = c;
-//                    }
-//                } else {
-//                    mapFullTable[keys[0]] = 0;
-//                }
-//
-//                CharPalette palette = new CharPalette();
-//                palette.set(keys);
-//
-//                int bits = MathHelper.log2(unique - 1);
-//                BitArray4096 encodedData = new BitArray4096(bits);
-//
-//                for (int i = 0; i < raw.length; i++) {
-//                    mapBitTable[i] = mapFullTable[raw[i]];
-//                }
-//
-//                encodedData.fromRaw(mapBitTable);
-//
-//                this.palette = palette;
-//                this.encodedData = encodedData;
-//                rawData = null;
-//                return true;
+                char unique = 0;
+
+                boolean[] countTable = ThreadCache.boolCache4096.get();
+                char[] mapFullTable = ThreadCache.charCache4096.get();
+                char[] mapBitTable = ThreadCache.charCache4096v2.get();
+                Arrays.fill(countTable, false);
+                for (char c : raw) {
+                    if (!countTable[c]) {
+                        mapBitTable[unique] = c;
+                        countTable[c] = true;
+                        unique++;
+                    }
+                }
+
+                char[] keys = Arrays.copyOfRange(mapBitTable, 0, unique);
+                if (keys.length > 1) {
+                    Arrays.sort(keys);
+                    for (char c = 0; c < keys.length; c++) {
+                        mapFullTable[keys[c]] = c;
+                    }
+                } else {
+                    mapFullTable[keys[0]] = 0;
+                }
+
+                CharPalette palette = new CharPalette();
+                palette.set(keys);
+
+                int bits = MathHelper.log2(unique - 1);
+                BitArray4096 encodedData = new BitArray4096(bits);
+
+                for (int i = 0; i < raw.length; i++) {
+                    mapBitTable[i] = mapFullTable[raw[i]];
+                }
+
+                encodedData.fromRaw(mapBitTable);
+
+                this.palette = palette;
+                this.encodedData = encodedData;
+                rawData = null;
+                return true;
             }
         }
         return false;

--- a/src/main/java/cn/nukkit/level/generator/task/GenerationTask.java
+++ b/src/main/java/cn/nukkit/level/generator/task/GenerationTask.java
@@ -41,18 +41,20 @@ public class GenerationTask extends AsyncTask {
         manager.cleanChunks(level.getSeed());
         synchronized (manager) {
             try {
-                BaseFullChunk chunk = this.chunk.clone();
+                BaseFullChunk chunk = this.chunk;
 
                 if (chunk == null) {
                     return;
                 }
 
-                manager.setChunk(chunk.getX(), chunk.getZ(), chunk);
-
-                generator.generateChunk(chunk.getX(), chunk.getZ());
-
-                chunk = manager.getChunk(chunk.getX(), chunk.getZ());
-                chunk.setGenerated();
+                synchronized (chunk) {
+                    if (!chunk.isGenerated()) {
+                        manager.setChunk(chunk.getX(), chunk.getZ(), chunk);
+                        generator.generateChunk(chunk.getX(), chunk.getZ());
+                        chunk = manager.getChunk(chunk.getX(), chunk.getZ());
+                        chunk.setGenerated();
+                    }
+                }
                 this.chunk = chunk;
                 state = true;
             } finally {


### PR DESCRIPTION
By being able to directly modify the chunk, it avoids multiple expensive chunk.clone() calls during generation/population. 

This also fixes:
 - Chunk population sometimes setting a chunk multiple times
 - A ground cover issue with custom generators: https://i.imgur.com/ppKZjLK.gifv @DaPorkchop_