### PR TITLE
re-add version to motd string

### DIFF
--- a/src/main/java/cn/nukkit/network/RakNetInterface.java
+++ b/src/main/java/cn/nukkit/network/RakNetInterface.java
@@ -213,7 +213,8 @@ public class RakNetInterface implements ServerInstance, AdvancedSourceInterface 
         String[] names = name.split("!@#");  //Split double names within the program
         this.handler.sendOption("name",
                 "MCPE;" + Utils.rtrim(names[0].replace(";", "\\;"), '\\') + ";" +
-                        ProtocolInfo.CURRENT_PROTOCOL + ";;" +
+                        ProtocolInfo.CURRENT_PROTOCOL + ";" +
+                        ProtocolInfo.MINECRAFT_VERSION_NETWORK + ";" +
                         info.getPlayerCount() + ";" +
                         info.getMaxPlayerCount() + ";" +
                         this.server.getServerUniqueId().toString() + ";" +


### PR DESCRIPTION
was described as having no issues when removed. however, i've found that it:

- causes issues with a number of server lists, causing it to show the version as `;0` and break other values
- breaks mcpe pinging software, for example [JRakNet's](https://github.com/JRakNet/JRakNet/blob/master/src/main/java/com/whirvis/jraknet/identifier/MinecraftIdentifier.java#L131-L132)