### PR TITLE
Use Trove for primitive lists, maps and sets.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,26 +20,35 @@
             <id>aikar</id>
             <url>http://ci.emc.gs/nexus/content/groups/aikar/</url>
         </repository>
+        <repository>
+            <id>nukkit-repo</id>
+            <url>https://repo.nukkitx.com/main/</url>
+        </repository>
     </repositories>
 
     <distributionManagement>
         <repository>
             <id>central</id>
-            <name>potestas-releases</name>
-            <url>https://repo.potestas.xyz/main</url>
+            <name>nukkit-releases</name>
+            <url>https://repo.nukkitx.com/release/</url>
         </repository>
         <snapshotRepository>
             <id>snapshots</id>
-            <name>potestas-snapshots</name>
-            <url>https://repo.potestas.xyz/main</url>
+            <name>nukkit-snapshots</name>
+            <url>https://repo.nukkitx.com/snapshot/</url>
         </snapshotRepository>
     </distributionManagement>
 
     <dependencies>
         <dependency>
-            <groupId>it.unimi.dsi</groupId>
-            <artifactId>fastutil</artifactId>
-            <version>8.1.1</version>
+            <groupId>net.sf.trove4j</groupId>
+            <artifactId>trove</artifactId>
+            <version>3.1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.trove4j</groupId>
+            <artifactId>trove-experimental</artifactId>
+            <version>3.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.fusesource.jansi</groupId>

--- a/src/main/java/cn/nukkit/block/BlockLeaves.java
+++ b/src/main/java/cn/nukkit/block/BlockLeaves.java
@@ -11,8 +11,8 @@ import cn.nukkit.level.Level;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.utils.BlockColor;
 import cn.nukkit.utils.Hash;
-import it.unimi.dsi.fastutil.longs.LongArraySet;
-import it.unimi.dsi.fastutil.longs.LongSet;
+import gnu.trove.set.TLongSet;
+import gnu.trove.set.hash.TLongHashSet;
 
 /**
  * author: Angelic47
@@ -116,7 +116,7 @@ public class BlockLeaves extends BlockTransparentMeta {
                 LeavesDecayEvent ev = new LeavesDecayEvent(this);
 
                 Server.getInstance().getPluginManager().callEvent(ev);
-                if (ev.isCancelled() || findLog(this, new LongArraySet(), 0, check)) {
+                if (ev.isCancelled() || findLog(this, new TLongHashSet(), 0, check)) {
                     getLevel().setBlock(this, this, false, false);
                 } else {
                     getLevel().useBreakOn(this);
@@ -127,11 +127,11 @@ public class BlockLeaves extends BlockTransparentMeta {
         return 0;
     }
 
-    private Boolean findLog(Block pos, LongSet visited, Integer distance, Integer check) {
+    private Boolean findLog(Block pos, TLongSet visited, Integer distance, Integer check) {
         return findLog(pos, visited, distance, check, null);
     }
 
-    private Boolean findLog(Block pos, LongSet visited, Integer distance, Integer check, BlockFace fromSide) {
+    private Boolean findLog(Block pos, TLongSet visited, Integer distance, Integer check, BlockFace fromSide) {
         ++check;
         long index = Hash.hashBlock((int) pos.x, (int) pos.y, (int) pos.z);
         if (visited.contains(index)) return false;

--- a/src/main/java/cn/nukkit/block/BlockLiquid.java
+++ b/src/main/java/cn/nukkit/block/BlockLiquid.java
@@ -7,8 +7,8 @@ import cn.nukkit.level.Sound;
 import cn.nukkit.level.particle.SmokeParticle;
 import cn.nukkit.math.AxisAlignedBB;
 import cn.nukkit.math.Vector3;
-import it.unimi.dsi.fastutil.longs.Long2ByteMap;
-import it.unimi.dsi.fastutil.longs.Long2ByteOpenHashMap;
+import gnu.trove.map.TLongByteMap;
+import gnu.trove.map.hash.TLongByteHashMap;
 
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -23,7 +23,7 @@ public abstract class BlockLiquid extends BlockTransparentMeta {
     private final byte BLOCKED = -1;
     public int adjacentSources = 0;
     protected Vector3 flowVector = null;
-    private Long2ByteMap flowCostVisited = new Long2ByteOpenHashMap();
+    private TLongByteMap flowCostVisited = new TLongByteHashMap();
 
     protected BlockLiquid(int meta) {
         super(meta);

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityJukebox.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityJukebox.java
@@ -58,7 +58,7 @@ public class BlockEntityJukebox extends BlockEntitySpawnable {
             pk.y = getFloorY();
             pk.z = getFloorZ();
 
-            Server.broadcastPacket(this.level.getPlayers().values(), pk);
+            Server.broadcastPacket(this.level.getPlayers(), pk);
         }
     }
 
@@ -67,7 +67,7 @@ public class BlockEntityJukebox extends BlockEntitySpawnable {
             StopSoundPacket pk = new StopSoundPacket();
             pk.name = ((ItemRecord) this.recordItem).getSoundId();
 
-            Server.broadcastPacket(this.level.getPlayers().values(), pk);
+            Server.broadcastPacket(this.level.getPlayers(), pk);
         }
     }
 

--- a/src/main/java/cn/nukkit/blockentity/BlockEntitySpawnable.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntitySpawnable.java
@@ -51,7 +51,7 @@ public abstract class BlockEntitySpawnable extends BlockEntity {
             return;
         }
 
-        for (Player player : this.getLevel().getChunkPlayers(this.chunk.getX(), this.chunk.getZ()).values()) {
+        for (Player player : this.getLevel().getChunkPlayers(this.chunk.getX(), this.chunk.getZ()).values(new Player[0])) {
             if (player.spawned) {
                 this.spawnTo(player);
             }

--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -34,6 +34,7 @@ import cn.nukkit.utils.MainLogger;
 import co.aikar.timings.Timing;
 import co.aikar.timings.Timings;
 import co.aikar.timings.TimingsHistory;
+import gnu.trove.map.TIntObjectMap;
 
 import java.lang.reflect.Constructor;
 import java.util.*;
@@ -1770,7 +1771,7 @@ public abstract class Entity extends Location implements Metadatable {
             this.chunk = this.level.getChunk((int) this.x >> 4, (int) this.z >> 4, true);
 
             if (!this.justCreated) {
-                Map<Integer, Player> newChunk = this.level.getChunkPlayers((int) this.x >> 4, (int) this.z >> 4);
+                TIntObjectMap<Player> newChunk = this.level.getChunkPlayers((int) this.x >> 4, (int) this.z >> 4);
                 for (Player player : new ArrayList<>(this.hasSpawned.values())) {
                     if (!newChunk.containsKey(player.getLoaderId())) {
                         this.despawnFrom(player);
@@ -1779,7 +1780,7 @@ public abstract class Entity extends Location implements Metadatable {
                     }
                 }
 
-                for (Player player : newChunk.values()) {
+                for (Player player : newChunk.values(new Player[0])) {
                     this.spawnTo(player);
                 }
             }
@@ -1917,7 +1918,7 @@ public abstract class Entity extends Location implements Metadatable {
             return;
         }
 
-        for (Player player : this.level.getChunkPlayers(this.chunk.getX(), this.chunk.getZ()).values()) {
+        for (Player player : this.level.getChunkPlayers(this.chunk.getX(), this.chunk.getZ()).values(new Player[0])) {
             if (player.isOnline()) {
                 this.spawnTo(player);
             }

--- a/src/main/java/cn/nukkit/entity/item/EntityXPOrb.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityXPOrb.java
@@ -125,7 +125,7 @@ public class EntityXPOrb extends Entity {
             }
 
             if (this.closestPlayer == null || this.closestPlayer.distanceSquared(this) > 64.0D) {
-                for (Player p : level.getPlayers().values()) {
+                for (Player p : level.getPlayers()) {
                     if (!p.isSpectator() && p.distance(this) <= 8) {
                         this.closestPlayer = p;
                         break;

--- a/src/main/java/cn/nukkit/inventory/CraftingManager.java
+++ b/src/main/java/cn/nukkit/inventory/CraftingManager.java
@@ -9,8 +9,9 @@ import cn.nukkit.utils.BinaryStream;
 import cn.nukkit.utils.Config;
 import cn.nukkit.utils.MainLogger;
 import cn.nukkit.utils.Utils;
+import gnu.trove.map.TIntObjectMap;
+import gnu.trove.map.hash.TIntObjectHashMap;
 import io.netty.util.collection.CharObjectHashMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,14 +27,12 @@ public class CraftingManager {
     public final Collection<Recipe> recipes = new ArrayDeque<>();
 
     public static BatchPacket packet = null;
-    protected final Map<Integer, Map<UUID, ShapedRecipe>> shapedRecipes = new Int2ObjectOpenHashMap<>();
-
-    public final Map<Integer, FurnaceRecipe> furnaceRecipes = new Int2ObjectOpenHashMap<>();
-
-    public final Map<Integer, BrewingRecipe> brewingRecipes = new Int2ObjectOpenHashMap<>();
+    public final TIntObjectMap<FurnaceRecipe> furnaceRecipes = new TIntObjectHashMap<>();
+    public final TIntObjectMap<BrewingRecipe> brewingRecipes = new TIntObjectHashMap<>();
+    protected final TIntObjectMap<Map<UUID, ShapedRecipe>> shapedRecipes = new TIntObjectHashMap<>();
 
     private static int RECIPE_COUNT = 0;
-    protected final Map<Integer, Map<UUID, ShapelessRecipe>> shapelessRecipes = new Int2ObjectOpenHashMap<>();
+    protected final TIntObjectMap<Map<UUID, ShapelessRecipe>> shapelessRecipes = new TIntObjectHashMap<>();
 
     public static final Comparator<Item> recipeComparator = (i1, i2) -> {
         if (i1.getId() > i2.getId()) {
@@ -174,7 +173,7 @@ public class CraftingManager {
             }
         }
 
-        for (FurnaceRecipe recipe : this.getFurnaceRecipes().values()) {
+        for (FurnaceRecipe recipe : this.getFurnaceRecipes()) {
             pk.addFurnaceRecipe(recipe);
         }
         pk.encode();
@@ -186,8 +185,8 @@ public class CraftingManager {
         return recipes;
     }
 
-    public Map<Integer, FurnaceRecipe> getFurnaceRecipes() {
-        return furnaceRecipes;
+    public Collection<FurnaceRecipe> getFurnaceRecipes() {
+        return furnaceRecipes.valueCollection();
     }
 
     public FurnaceRecipe matchFurnaceRecipe(Item input) {
@@ -269,7 +268,8 @@ public class CraftingManager {
         UUID hash = getMultiItemHash(list);
 
         int resultHash = getItemHash(recipe.getResult());
-        Map<UUID, ShapelessRecipe> map = shapelessRecipes.computeIfAbsent(resultHash, k -> new HashMap<>());
+        shapelessRecipes.putIfAbsent(resultHash, new HashMap<>());
+        Map<UUID, ShapelessRecipe> map = shapelessRecipes.get(resultHash);
 
         map.put(hash, recipe);
     }

--- a/src/main/java/cn/nukkit/level/Explosion.java
+++ b/src/main/java/cn/nukkit/level/Explosion.java
@@ -16,7 +16,7 @@ import cn.nukkit.level.particle.HugeExplodeSeedParticle;
 import cn.nukkit.math.*;
 import cn.nukkit.network.protocol.ExplodePacket;
 import cn.nukkit.utils.Hash;
-import it.unimi.dsi.fastutil.longs.LongArraySet;
+import gnu.trove.set.hash.TLongHashSet;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -113,7 +113,7 @@ public class Explosion {
 
     public boolean explodeB() {
 
-        LongArraySet updateBlocks = new LongArraySet();
+        TLongHashSet updateBlocks = new TLongHashSet();
         List<Vector3> send = new ArrayList<>();
 
         Vector3 source = (new Vector3(this.source.x, this.source.y, this.source.z)).floor();

--- a/src/main/java/cn/nukkit/level/format/FullChunk.java
+++ b/src/main/java/cn/nukkit/level/format/FullChunk.java
@@ -4,8 +4,10 @@ import cn.nukkit.block.Block;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.level.generator.biome.Biome;
+import gnu.trove.map.TIntIntMap;
+import gnu.trove.map.TLongObjectMap;
+
 import java.io.IOException;
-import java.util.Map;
 
 /**
  * author: MagicDroidX
@@ -116,9 +118,9 @@ public interface FullChunk extends Cloneable {
 
     void removeBlockEntity(BlockEntity blockEntity);
 
-    Map<Long, Entity> getEntities();
+    TLongObjectMap<Entity> getEntities();
 
-    Map<Long, BlockEntity> getBlockEntities();
+    TLongObjectMap<BlockEntity> getBlockEntities();
 
     BlockEntity getTile(int x, int y, int z);
 
@@ -146,7 +148,7 @@ public interface FullChunk extends Cloneable {
 
     byte[] getBlockDataArray();
 
-    Map<Integer, Integer> getBlockExtraDataArray();
+    TIntIntMap getBlockExtraDataArray();
 
     byte[] getBlockSkyLightArray();
 

--- a/src/main/java/cn/nukkit/level/format/LevelProvider.java
+++ b/src/main/java/cn/nukkit/level/format/LevelProvider.java
@@ -5,6 +5,7 @@ import cn.nukkit.level.Level;
 import cn.nukkit.level.format.generic.BaseFullChunk;
 import cn.nukkit.math.Vector3;
 import cn.nukkit.scheduler.AsyncTask;
+import gnu.trove.map.TLongObjectMap;
 
 import java.util.Map;
 
@@ -92,7 +93,7 @@ public interface LevelProvider {
 
     void setSpawn(Vector3 pos);
 
-    Map<Long, ? extends FullChunk> getLoadedChunks();
+    TLongObjectMap<? extends FullChunk> getLoadedChunks();
 
     void doGarbageCollection();
 

--- a/src/main/java/cn/nukkit/level/format/anvil/Chunk.java
+++ b/src/main/java/cn/nukkit/level/format/anvil/Chunk.java
@@ -11,14 +11,21 @@ import cn.nukkit.level.format.generic.BaseChunk;
 import cn.nukkit.level.format.generic.EmptyChunkSection;
 import cn.nukkit.nbt.NBTIO;
 import cn.nukkit.nbt.tag.*;
-import cn.nukkit.utils.*;
+import cn.nukkit.utils.BinaryStream;
+import cn.nukkit.utils.BlockUpdateEntry;
+import cn.nukkit.utils.ChunkException;
+import cn.nukkit.utils.Zlib;
+import gnu.trove.map.TIntIntMap;
+import gnu.trove.map.hash.TIntIntHashMap;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.nio.ByteOrder;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Set;
 
 /**
  * author: MagicDroidX
@@ -81,10 +88,10 @@ public class Chunk extends BaseChunk {
             }
         }
 
-        Map<Integer, Integer> extraData = new HashMap<>();
+        TIntIntMap extraData = new TIntIntHashMap();
 
         Tag extra = nbt.get("ExtraData");
-        if (extra != null && extra instanceof ByteArrayTag) {
+        if (extra instanceof ByteArrayTag) {
             BinaryStream stream = new BinaryStream(((ByteArrayTag) extra).data);
             for (int i = 0; i < stream.getInt(); i++) {
                 int key = stream.getInt();
@@ -279,7 +286,7 @@ public class Chunk extends BaseChunk {
         }
 
         ArrayList<CompoundTag> entities = new ArrayList<>();
-        for (Entity entity : this.getEntities().values()) {
+        for (Entity entity : this.getEntities().values(new Entity[0])) {
             if (!(entity instanceof Player) && !entity.closed) {
                 entity.saveNBT();
                 entities.add(entity.namedTag);
@@ -290,7 +297,7 @@ public class Chunk extends BaseChunk {
         nbt.putList(entityListTag);
 
         ArrayList<CompoundTag> tiles = new ArrayList<>();
-        for (BlockEntity blockEntity : this.getBlockEntities().values()) {
+        for (BlockEntity blockEntity : this.getBlockEntities().values(new BlockEntity[0])) {
             blockEntity.saveNBT();
             tiles.add(blockEntity.namedTag);
         }
@@ -319,9 +326,9 @@ public class Chunk extends BaseChunk {
         }
 
         BinaryStream extraData = new BinaryStream();
-        Map<Integer, Integer> extraDataArray = this.getBlockExtraDataArray();
+        TIntIntMap extraDataArray = this.getBlockExtraDataArray();
         extraData.putInt(extraDataArray.size());
-        for (Integer key : extraDataArray.keySet()) {
+        for (Integer key : extraDataArray.keys()) {
             extraData.putInt(key);
             extraData.putShort(extraDataArray.get(key));
         }
@@ -370,7 +377,7 @@ public class Chunk extends BaseChunk {
         nbt.putIntArray("HeightMap", heightInts);
 
         ArrayList<CompoundTag> entities = new ArrayList<>();
-        for (Entity entity : this.getEntities().values()) {
+        for (Entity entity : this.getEntities().values(new Entity[0])) {
             if (!(entity instanceof Player) && !entity.closed) {
                 entity.saveNBT();
                 entities.add(entity.namedTag);
@@ -381,7 +388,7 @@ public class Chunk extends BaseChunk {
         nbt.putList(entityListTag);
 
         ArrayList<CompoundTag> tiles = new ArrayList<>();
-        for (BlockEntity blockEntity : this.getBlockEntities().values()) {
+        for (BlockEntity blockEntity : this.getBlockEntities().values(new BlockEntity[0])) {
             blockEntity.saveNBT();
             tiles.add(blockEntity.namedTag);
         }
@@ -410,9 +417,9 @@ public class Chunk extends BaseChunk {
         }
 
         BinaryStream extraData = new BinaryStream();
-        Map<Integer, Integer> extraDataArray = this.getBlockExtraDataArray();
+        TIntIntMap extraDataArray = this.getBlockExtraDataArray();
         extraData.putInt(extraDataArray.size());
-        for (Integer key : extraDataArray.keySet()) {
+        for (Integer key : extraDataArray.keys()) {
             extraData.putInt(key);
             extraData.putShort(extraDataArray.get(key));
         }

--- a/src/main/java/cn/nukkit/level/format/anvil/ChunkRequestTask.java
+++ b/src/main/java/cn/nukkit/level/format/anvil/ChunkRequestTask.java
@@ -35,7 +35,7 @@ public class ChunkRequestTask extends AsyncTask {
 
         byte[] buffer = new byte[0];
 
-        for (BlockEntity blockEntity : chunk.getBlockEntities().values()) {
+        for (BlockEntity blockEntity : chunk.getBlockEntities().values(new BlockEntity[0])) {
             if (blockEntity instanceof BlockEntitySpawnable) {
                 try {
                     buffer = Binary.appendBytes(buffer, NBTIO.write(((BlockEntitySpawnable) blockEntity).getSpawnCompound(), ByteOrder.BIG_ENDIAN, true));

--- a/src/main/java/cn/nukkit/level/format/generic/BaseFullChunk.java
+++ b/src/main/java/cn/nukkit/level/format/generic/BaseFullChunk.java
@@ -14,24 +14,26 @@ import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.nbt.tag.ListTag;
 import cn.nukkit.nbt.tag.NumberTag;
 import cn.nukkit.network.protocol.BatchPacket;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import gnu.trove.map.TIntIntMap;
+import gnu.trove.map.TIntObjectMap;
+import gnu.trove.map.TLongObjectMap;
+import gnu.trove.map.hash.TIntIntHashMap;
+import gnu.trove.map.hash.TIntObjectHashMap;
+import gnu.trove.map.hash.TLongObjectHashMap;
+
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 /**
  * author: MagicDroidX
  * Nukkit Project
  */
 public abstract class BaseFullChunk implements FullChunk, ChunkManager {
-    protected Map<Long, Entity> entities;
+    protected TLongObjectMap<Entity> entities;
 
-    protected Map<Long, BlockEntity> tiles;
+    protected TLongObjectMap<BlockEntity> tiles;
 
-    protected Map<Integer, BlockEntity> tileList;
+    protected TIntObjectMap<BlockEntity> tileList;
 
     protected BiomePalette biomes;
 
@@ -49,7 +51,7 @@ public abstract class BaseFullChunk implements FullChunk, ChunkManager {
 
     protected List<CompoundTag> NBTentities;
 
-    protected Map<Integer, Integer> extraData;
+    protected TIntIntMap extraData;
 
     protected LevelProvider provider;
     protected Class<? extends LevelProvider> providerClass;
@@ -292,7 +294,7 @@ public abstract class BaseFullChunk implements FullChunk, ChunkManager {
                 this.extraData.remove(Level.chunkBlockHash(x, y, z));
             }
         } else {
-            if (this.extraData == null) this.extraData = new Int2ObjectOpenHashMap<>();
+            if (this.extraData == null) this.extraData = new TIntIntHashMap();
             this.extraData.put(Level.chunkBlockHash(x, y, z), data);
         }
 
@@ -343,7 +345,7 @@ public abstract class BaseFullChunk implements FullChunk, ChunkManager {
     @Override
     public void addEntity(Entity entity) {
         if (this.entities == null) {
-            this.entities = new Long2ObjectOpenHashMap<>();
+            this.entities = new TLongObjectHashMap<>();
         }
         this.entities.put(entity.getId(), entity);
         if (!(entity instanceof Player) && this.isInit) {
@@ -364,8 +366,8 @@ public abstract class BaseFullChunk implements FullChunk, ChunkManager {
     @Override
     public void addBlockEntity(BlockEntity blockEntity) {
         if (this.tiles == null) {
-            this.tiles = new Long2ObjectOpenHashMap<>();
-            this.tileList = new Int2ObjectOpenHashMap<>();
+            this.tiles = new TLongObjectHashMap<>();
+            this.tileList = new TIntObjectHashMap<>();
         }
         this.tiles.put(blockEntity.getId(), blockEntity);
         int index = ((blockEntity.getFloorZ() & 0x0f) << 12) | ((blockEntity.getFloorX() & 0x0f) << 8) | (blockEntity.getFloorY() & 0xff);
@@ -391,18 +393,18 @@ public abstract class BaseFullChunk implements FullChunk, ChunkManager {
     }
 
     @Override
-    public Map<Long, Entity> getEntities() {
-        return entities == null ? Collections.emptyMap() : entities;
+    public TLongObjectMap<Entity> getEntities() {
+        return entities == null ? new TLongObjectHashMap<>() : entities;
     }
 
     @Override
-    public Map<Long, BlockEntity> getBlockEntities() {
-        return tiles == null ? Collections.emptyMap() : tiles;
+    public TLongObjectMap<BlockEntity> getBlockEntities() {
+        return tiles == null ? new TLongObjectHashMap<>() : tiles;
     }
 
     @Override
-    public Map<Integer, Integer> getBlockExtraDataArray() {
-        return extraData == null ? Collections.emptyMap() : extraData;
+    public TIntIntMap getBlockExtraDataArray() {
+        return extraData == null ? new TIntIntHashMap() : extraData;
     }
 
     @Override
@@ -445,20 +447,20 @@ public abstract class BaseFullChunk implements FullChunk, ChunkManager {
             level.saveChunk(this.getX(), this.getZ());
         }
         if (safe) {
-            for (Entity entity : this.getEntities().values()) {
+            for (Entity entity : this.getEntities().values(new Entity[0])) {
                 if (entity instanceof Player) {
                     return false;
                 }
             }
         }
-        for (Entity entity : new ArrayList<>(this.getEntities().values())) {
+        for (Entity entity : this.getEntities().values(new Entity[0])) {
             if (entity instanceof Player) {
                 continue;
             }
             entity.close();
         }
 
-        for (BlockEntity blockEntity : new ArrayList<>(this.getBlockEntities().values())) {
+        for (BlockEntity blockEntity : this.getBlockEntities().values(new BlockEntity[0])) {
             blockEntity.close();
         }
         this.provider = null;

--- a/src/main/java/cn/nukkit/level/format/leveldb/Chunk.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/Chunk.java
@@ -17,12 +17,16 @@ import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.nbt.tag.Tag;
 import cn.nukkit.utils.Binary;
 import cn.nukkit.utils.BinaryStream;
+import gnu.trove.map.TIntIntMap;
+import gnu.trove.map.hash.TIntIntHashMap;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * author: MagicDroidX
@@ -53,7 +57,7 @@ public class Chunk extends BaseFullChunk {
         this(level, chunkX, chunkZ, terrain, entityData, tileData, null);
     }
 
-    public Chunk(LevelProvider level, int chunkX, int chunkZ, byte[] terrain, List<CompoundTag> entityData, List<CompoundTag> tileData, Map<Integer, Integer> extraData) {
+    public Chunk(LevelProvider level, int chunkX, int chunkZ, byte[] terrain, List<CompoundTag> entityData, List<CompoundTag> tileData, TIntIntMap extraData) {
         ByteBuffer buffer = ByteBuffer.wrap(terrain).order(ByteOrder.BIG_ENDIAN);
 
         byte[] blocks = new byte[32768];
@@ -336,7 +340,7 @@ public class Chunk extends BaseFullChunk {
             List<CompoundTag> entities = new ArrayList<>();
             List<CompoundTag> tiles = new ArrayList<>();
 
-            Map<Integer, Integer> extraDataMap = new HashMap<>();
+            TIntIntMap extraDataMap = new TIntIntHashMap();
 
             if (provider instanceof LevelDB) {
                 byte[] entityData = ((LevelDB) provider).getDatabase().get(EntitiesKey.create(chunkX, chunkZ).toArray());
@@ -436,7 +440,7 @@ public class Chunk extends BaseFullChunk {
 
                 List<CompoundTag> entities = new ArrayList<>();
 
-                for (Entity entity : this.getEntities().values()) {
+                for (Entity entity : this.getEntities().values(new Entity[0])) {
                     if (!(entity instanceof Player) && !entity.closed) {
                         entity.saveNBT();
                         entities.add(entity.namedTag);
@@ -452,7 +456,7 @@ public class Chunk extends BaseFullChunk {
 
                 List<CompoundTag> tiles = new ArrayList<>();
 
-                for (BlockEntity blockEntity : this.getBlockEntities().values()) {
+                for (BlockEntity blockEntity : this.getBlockEntities().values(new BlockEntity[0])) {
                     if (!blockEntity.closed) {
                         blockEntity.saveNBT();
                         entities.add(blockEntity.namedTag);
@@ -469,9 +473,9 @@ public class Chunk extends BaseFullChunk {
                 ExtraDataKey extraDataKey = ExtraDataKey.create(this.getX(), this.getZ());
                 if (!this.getBlockExtraDataArray().isEmpty()) {
                     BinaryStream extraData = new BinaryStream();
-                    Map<Integer, Integer> extraDataArray = this.getBlockExtraDataArray();
+                    TIntIntMap extraDataArray = this.getBlockExtraDataArray();
                     extraData.putInt(extraDataArray.size());
-                    for (Integer key : extraDataArray.keySet()) {
+                    for (Integer key : extraDataArray.keys()) {
                         extraData.putInt(key);
                         extraData.putShort(extraDataArray.get(key));
                     }

--- a/src/main/java/cn/nukkit/level/format/leveldb/LevelDB.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/LevelDB.java
@@ -19,6 +19,9 @@ import cn.nukkit.nbt.NBTIO;
 import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.scheduler.AsyncTask;
 import cn.nukkit.utils.*;
+import gnu.trove.map.TIntIntMap;
+import gnu.trove.map.TLongObjectMap;
+import gnu.trove.map.hash.TLongObjectHashMap;
 import org.iq80.leveldb.DB;
 import org.iq80.leveldb.Options;
 import org.iq80.leveldb.impl.Iq80DBFactory;
@@ -33,7 +36,7 @@ import java.util.*;
  */
 public class LevelDB implements LevelProvider {
 
-    protected Map<Long, Chunk> chunks = new HashMap<>();
+    protected TLongObjectMap<Chunk> chunks = new TLongObjectHashMap<>();
 
     protected DB db;
 
@@ -169,7 +172,7 @@ public class LevelDB implements LevelProvider {
         if (!chunk.getBlockEntities().isEmpty()) {
             List<CompoundTag> tagList = new ArrayList<>();
 
-            for (BlockEntity blockEntity : chunk.getBlockEntities().values()) {
+            for (BlockEntity blockEntity : chunk.getBlockEntities().values(new BlockEntity[0])) {
                 if (blockEntity instanceof BlockEntitySpawnable) {
                     tagList.add(((BlockEntitySpawnable) blockEntity).getSpawnCompound());
                 }
@@ -182,7 +185,7 @@ public class LevelDB implements LevelProvider {
             }
         }
 
-        Map<Integer, Integer> extra = chunk.getBlockExtraDataArray();
+        TIntIntMap extra = chunk.getBlockExtraDataArray();
         BinaryStream extraData;
         if (!extra.isEmpty()) {
             extraData = new BinaryStream();
@@ -218,10 +221,10 @@ public class LevelDB implements LevelProvider {
 
     @Override
     public void unloadChunks() {
-        for (Chunk chunk : new ArrayList<>(this.chunks.values())) {
+        for (Chunk chunk : this.chunks.values(new Chunk[0])) {
             this.unloadChunk(chunk.getX(), chunk.getZ(), false);
         }
-        this.chunks = new HashMap<>();
+        this.chunks = new TLongObjectHashMap<>();
     }
 
     @Override
@@ -249,7 +252,7 @@ public class LevelDB implements LevelProvider {
     }
 
     @Override
-    public Map<Long, Chunk> getLoadedChunks() {
+    public TLongObjectMap<Chunk> getLoadedChunks() {
         return this.chunks;
     }
 
@@ -265,7 +268,7 @@ public class LevelDB implements LevelProvider {
 
     @Override
     public void saveChunks() {
-        for (Chunk chunk : this.chunks.values()) {
+        for (Chunk chunk : this.chunks.values(new Chunk[0])) {
             this.saveChunk(chunk.getX(), chunk.getZ());
         }
     }

--- a/src/main/java/cn/nukkit/level/format/mcregion/Chunk.java
+++ b/src/main/java/cn/nukkit/level/format/mcregion/Chunk.java
@@ -15,13 +15,13 @@ import cn.nukkit.nbt.tag.ListTag;
 import cn.nukkit.utils.Binary;
 import cn.nukkit.utils.BinaryStream;
 import cn.nukkit.utils.Zlib;
+import gnu.trove.map.TIntIntMap;
+import gnu.trove.map.hash.TIntIntHashMap;
 
 import java.io.ByteArrayInputStream;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * author: MagicDroidX
@@ -87,7 +87,7 @@ public class Chunk extends BaseFullChunk {
             this.nbt.putByteArray("BlockLight", new byte[16384]);
         }
 
-        Map<Integer, Integer> extraData = new HashMap<>();
+        TIntIntMap extraData = new TIntIntHashMap();
 
         if (!this.nbt.contains("ExtraData") || !(this.nbt.get("ExtraData") instanceof ByteArrayTag)) {
             this.nbt.putByteArray("ExtraData", Binary.writeInt(0));
@@ -457,7 +457,7 @@ public class Chunk extends BaseFullChunk {
 
 
         ArrayList<CompoundTag> entities = new ArrayList<>();
-        for (Entity entity : this.getEntities().values()) {
+        for (Entity entity : this.getEntities().values(new Entity[0])) {
             if (!(entity instanceof Player) && !entity.closed) {
                 entity.saveNBT();
                 entities.add(entity.namedTag);
@@ -468,7 +468,7 @@ public class Chunk extends BaseFullChunk {
         nbt.putList(entityListTag);
 
         ArrayList<CompoundTag> tiles = new ArrayList<>();
-        for (BlockEntity blockEntity : this.getBlockEntities().values()) {
+        for (BlockEntity blockEntity : this.getBlockEntities().values(new BlockEntity[0])) {
             blockEntity.saveNBT();
             tiles.add(blockEntity.namedTag);
         }
@@ -477,9 +477,9 @@ public class Chunk extends BaseFullChunk {
         nbt.putList(tileListTag);
 
         BinaryStream extraData = new BinaryStream();
-        Map<Integer, Integer> extraDataArray = this.getBlockExtraDataArray();
+        TIntIntMap extraDataArray = this.getBlockExtraDataArray();
         extraData.putInt(extraDataArray.size());
-        for (Integer key : extraDataArray.keySet()) {
+        for (Integer key : extraDataArray.keys()) {
             extraData.putInt(key);
             extraData.putShort(extraDataArray.get(key));
         }

--- a/src/main/java/cn/nukkit/level/format/mcregion/McRegion.java
+++ b/src/main/java/cn/nukkit/level/format/mcregion/McRegion.java
@@ -15,6 +15,9 @@ import cn.nukkit.scheduler.AsyncTask;
 import cn.nukkit.utils.Binary;
 import cn.nukkit.utils.BinaryStream;
 import cn.nukkit.utils.ChunkException;
+import gnu.trove.iterator.TIntIntIterator;
+import gnu.trove.map.TIntIntMap;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -110,7 +113,7 @@ public class McRegion extends BaseLevelProvider {
         if (!chunk.getBlockEntities().isEmpty()) {
             List<CompoundTag> tagList = new ArrayList<>();
 
-            for (BlockEntity blockEntity : chunk.getBlockEntities().values()) {
+            for (BlockEntity blockEntity : chunk.getBlockEntities().values(new BlockEntity[0])) {
                 if (blockEntity instanceof BlockEntitySpawnable) {
                     tagList.add(((BlockEntitySpawnable) blockEntity).getSpawnCompound());
                 }
@@ -123,14 +126,16 @@ public class McRegion extends BaseLevelProvider {
             }
         }
 
-        Map<Integer, Integer> extra = chunk.getBlockExtraDataArray();
+        TIntIntMap extra = chunk.getBlockExtraDataArray();
         BinaryStream extraData;
         if (!extra.isEmpty()) {
             extraData = new BinaryStream();
             extraData.putLInt(extra.size());
-            for (Map.Entry<Integer, Integer> entry : extra.entrySet()) {
-                extraData.putLInt(entry.getKey());
-                extraData.putLShort(entry.getValue());
+            TIntIntIterator iter = extra.iterator();
+            while (iter.hasNext()) {
+                iter.advance();
+                extraData.putLInt(iter.key());
+                extraData.putLShort(iter.value());
             }
         } else {
             extraData = null;

--- a/src/main/java/co/aikar/timings/TimingsHistory.java
+++ b/src/main/java/co/aikar/timings/TimingsHistory.java
@@ -33,12 +33,12 @@ import cn.nukkit.timings.JsonUtil;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+
 import java.lang.management.ManagementFactory;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-
 
 import static co.aikar.timings.Timings.fullServerTickTimer;
 import static co.aikar.timings.TimingsManager.MINUTE_REPORTS;
@@ -97,12 +97,12 @@ public class TimingsHistory {
         // Information about all loaded entities/block entities
         for (Level level : Server.getInstance().getLevels().values()) {
             JsonArray jsonLevel = new JsonArray();
-            for (FullChunk chunk : level.getChunks().values()) {
+            for (FullChunk chunk : level.getChunks().valueCollection()) {
                 entityCounts.clear();
                 blockEntityCounts.clear();
 
                 //count entities
-                for (Entity entity : chunk.getEntities().values()) {
+                for (Entity entity : chunk.getEntities().values(new Player[0])) {
                     if (!entityCounts.containsKey(entity.getNetworkId()))
                         entityCounts.put(entity.getNetworkId(), new AtomicInteger(0));
                     entityCounts.get(entity.getNetworkId()).incrementAndGet();
@@ -110,7 +110,7 @@ public class TimingsHistory {
                 }
 
                 //count block entities
-                for (BlockEntity blockEntity : chunk.getBlockEntities().values()) {
+                for (BlockEntity blockEntity : chunk.getBlockEntities().values(new BlockEntity[0])) {
                     if (!blockEntityCounts.containsKey(blockEntity.getBlock().getId()))
                         blockEntityCounts.put(blockEntity.getBlock().getId(), new AtomicInteger(0));
                     blockEntityCounts.get(blockEntity.getBlock().getId()).incrementAndGet();


### PR DESCRIPTION
Jar size is down to 13MBs

`level.getPlayers()` will now return `Collection<Player>` instead of `Map<Long, Player>`
You can still get a player by entity Id using `getPlayer(long id)` which returns `Optional<Player>`

This change needs testing before merging and will break plugins access level for certain information.
Download: https://ci.nukkitx.com/job/NukkitX/job/trove/