### PR TITLE
Don't shade no-op slf4j implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,17 +91,6 @@
             <classifier>linux-x86_64</classifier>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-nop</artifactId>
-            <version>1.7.25</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>${junit.jupiter.version}</version>


### PR DESCRIPTION
The presence of this dependency on the classpath prevents plugins from using (libraries which depend on) slf4j.

This was first added in https://github.com/NukkitX/Nukkit/commit/822ff86d51ad8c723e02132b794cf44dc553267c - I assume because it was needed by "Oshi Core" - which has since been removed in https://github.com/NukkitX/Nukkit/commit/98d03a6f79a54ab4bed41d17a84cff0afbef837d