### PR TITLE
Fix issue with matchFurnaceRecipe() lookup not assigning the recipe i…

### DIFF
--- a/src/main/java/cn/nukkit/inventory/CraftingManager.java
+++ b/src/main/java/cn/nukkit/inventory/CraftingManager.java
@@ -192,7 +192,7 @@ public class CraftingManager {
 
     public FurnaceRecipe matchFurnaceRecipe(Item input) {
         FurnaceRecipe recipe = this.furnaceRecipes.get(getItemHash(input));
-        if (recipe == null) this.furnaceRecipes.get(getItemHash(input.getId(), 0));
+        if (recipe == null) recipe = this.furnaceRecipes.get(getItemHash(input.getId(), 0));
         return recipe;
     }
 


### PR DESCRIPTION
…n CraftingManager.java

Recipes like creating coal from wood in the furnace were failing as a result of this issue.