### PR TITLE
supported time command arguments for "noon", "sunset", "sunrise", "midnight"

### DIFF
--- a/src/main/java/cn/nukkit/command/defaults/TimeCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/TimeCommand.java
@@ -103,6 +103,14 @@ public class TimeCommand extends VanillaCommand {
                 value = Level.TIME_DAY;
             } else if ("night".equals(args[1])) {
                 value = Level.TIME_NIGHT;
+            } else if ("midnight".equals(args[1])) {
+                value = Level.TIME_MIDNIGHT;
+            } else if ("noon".equals(args[1])) {
+                value = Level.TIME_NOON;
+            } else if ("sunrise".equals(args[1])) {
+                value = Level.TIME_SUNRISE;
+            } else if ("sunset".equals(args[1])) {
+                value = Level.TIME_SUNSET;
             } else {
                 try {
                     value = Math.max(0, Integer.parseInt(args[1]));

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -89,8 +89,10 @@ public class Level implements ChunkManager, Metadatable {
     public static final int BLOCK_UPDATE_TICK = 7;
 
     public static final int TIME_DAY = 0;
+    public static final int TIME_NOON = 6000;
     public static final int TIME_SUNSET = 12000;
     public static final int TIME_NIGHT = 14000;
+    public static final int TIME_MIDNIGHT = 18000;
     public static final int TIME_SUNRISE = 23000;
 
     public static final int TIME_FULL = 24000;


### PR DESCRIPTION
I added "noon", "sunset", "sunrise" and "midnight" arguments into "time" command's arguments.