### PR TITLE
Fix fall damage w/ water landing

### DIFF
--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -1394,7 +1394,8 @@ public abstract class Entity extends Location implements Metadatable {
             fallDistance = (float) (this.highestPosition - this.y);
 
             if (fallDistance > 0) {
-                if (this instanceof EntityLiving && !this.isInsideOfWater()) {
+                // check if we fell into at least 1 block of water
+                if (this instanceof EntityLiving && !(this.getLevelBlock() instanceof BlockWater)) {
                     this.fall(fallDistance);
                 }
                 this.resetFallDistance();


### PR DESCRIPTION
In current minecraft, no damage is taken if any amount of water is beneath you, however unrealistic this is.

Fixes #118 