### PR TITLE
Fix shulker boxes not saving items

### DIFF
--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -256,7 +256,6 @@ public abstract class Block extends Position implements Metadatable, Cloneable, 
             list[PURPUR_STAIRS] = BlockStairsPurpur.class; //203
             
             list[UNDYED_SHULKER_BOX] = BlockUndyedShulkerBox.class; //205
-
             list[END_BRICKS] = BlockBricksEndStone.class; //206
 
             list[END_ROD] = BlockEndRod.class; //208

--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -254,6 +254,8 @@ public abstract class Block extends Position implements Metadatable, Cloneable, 
             list[PURPUR_BLOCK] = BlockPurpur.class; //201
 
             list[PURPUR_STAIRS] = BlockStairsPurpur.class; //203
+            
+            list[UNDYED_SHULKER_BOX] = BlockUndyedShulkerBox.class; //205
 
             list[END_BRICKS] = BlockBricksEndStone.class; //206
 

--- a/src/main/java/cn/nukkit/block/BlockID.java
+++ b/src/main/java/cn/nukkit/block/BlockID.java
@@ -260,8 +260,8 @@ public interface BlockID {
     int PURPUR_BLOCK = 201;
 
     int PURPUR_STAIRS = 203;
-    int DOUBLE_PURPUR_SLAB = 204;
-    int PURPUR_SLAB = 205;
+    //int DOUBLE_PURPUR_SLAB = 204;
+    int UNDYED_SHULKER_BOX = 205;
     int END_BRICKS = 206;
     //Note: frosted ice CAN NOT BE HARVESTED WITH HAND -- canHarvestWithHand method should be overridden FALSE.
     int ICE_FROSTED = 207;

--- a/src/main/java/cn/nukkit/block/BlockShulkerBox.java
+++ b/src/main/java/cn/nukkit/block/BlockShulkerBox.java
@@ -63,8 +63,7 @@ public class BlockShulkerBox extends BlockTransparentMeta {
                         
         BlockEntityShulkerBox t = (BlockEntityShulkerBox)this.getLevel().getBlockEntity(this);
         
-        if (t != null)
-        {
+        if (t != null) {
             ShulkerBoxInventory i = t.getRealInventory();
             
             CompoundTag nbt = item.getNamedTag();
@@ -73,10 +72,8 @@ public class BlockShulkerBox extends BlockTransparentMeta {
             
             ListTag<CompoundTag> items = new ListTag<>();
             
-            for (int it = 0; it < i.getSize(); it++)
-            {
-                if (i.getItem(it).getId() != Item.AIR)
-                {
+            for (int it = 0; it < i.getSize(); it++) {
+                if (i.getItem(it).getId() != Item.AIR) {
                     CompoundTag d = NBTIO.putItemHelper(i.getItem(it), it);
                     items.add(d);
                 }
@@ -86,8 +83,9 @@ public class BlockShulkerBox extends BlockTransparentMeta {
                 
             item.setCompoundTag(nbt);
             
-            if (t.hasName())
+            if (t.hasName()) {
                 item.setCustomName(t.getName());
+            }
         }
         
         return item;
@@ -138,10 +136,8 @@ public class BlockShulkerBox extends BlockTransparentMeta {
 
         CompoundTag t = item.getNamedTag();
             
-        if (t != null)
-        {
-            if (t.contains("Items"))
-            {
+        if (t != null) {
+            if (t.contains("Items")) {
                 nbt.putList(t.getList("Items"));
             }
         }

--- a/src/main/java/cn/nukkit/block/BlockShulkerBox.java
+++ b/src/main/java/cn/nukkit/block/BlockShulkerBox.java
@@ -3,9 +3,12 @@ package cn.nukkit.block;
 import cn.nukkit.Player;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.blockentity.BlockEntityShulkerBox;
+import cn.nukkit.inventory.ShulkerBoxInventory;
 import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemBlock;
 import cn.nukkit.item.ItemTool;
 import cn.nukkit.math.BlockFace;
+import cn.nukkit.nbt.NBTIO;
 import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.nbt.tag.ListTag;
 import cn.nukkit.nbt.tag.Tag;
@@ -53,6 +56,42 @@ public class BlockShulkerBox extends BlockTransparentMeta {
     public int getToolType() {
         return ItemTool.TYPE_PICKAXE;
     }
+    
+    @Override
+    public Item toItem() {
+        ItemBlock item = new ItemBlock(this, this.getDamage(), 1);
+                        
+        BlockEntityShulkerBox t = (BlockEntityShulkerBox)this.getLevel().getBlockEntity(this);
+        
+        if (t != null)
+        {
+            ShulkerBoxInventory i = t.getRealInventory();
+            
+            CompoundTag nbt = item.getNamedTag();
+            if (nbt == null)
+                nbt = new CompoundTag("");
+            
+            ListTag<CompoundTag> items = new ListTag<>();
+            
+            for (int it = 0; it < i.getSize(); it++)
+            {
+                if (i.getItem(it).getId() != Item.AIR)
+                {
+                    CompoundTag d = NBTIO.putItemHelper(i.getItem(it), it);
+                    items.add(d);
+                }
+            }
+            
+            nbt.put("Items", items);
+                
+            item.setCompoundTag(nbt);
+            
+            if (t.hasName())
+                item.setCustomName(t.getName());
+        }
+        
+        return item;
+    }
 
     @Override
     public Item[] getDrops(Item item) {
@@ -97,10 +136,13 @@ public class BlockShulkerBox extends BlockTransparentMeta {
             nbt.putString("CustomName", item.getCustomName());
         }
 
-        if (item.hasCustomBlockData()) {
-            Map<String, Tag> customData = item.getCustomBlockData().getTags();
-            for (Map.Entry<String, Tag> tag : customData.entrySet()) {
-                nbt.put(tag.getKey(), tag.getValue());
+        CompoundTag t = item.getNamedTag();
+            
+        if (t != null)
+        {
+            if (t.contains("Items"))
+            {
+                nbt.putList(t.getList("Items"));
             }
         }
 

--- a/src/main/java/cn/nukkit/block/BlockUndyedShulkerBox.java
+++ b/src/main/java/cn/nukkit/block/BlockUndyedShulkerBox.java
@@ -1,0 +1,19 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package cn.nukkit.block;
+
+
+/**
+ *
+ * @author Reece Mackie
+ */
+public class BlockUndyedShulkerBox extends BlockShulkerBox {
+    
+    @Override
+    public int getId() {
+        return UNDYED_SHULKER_BOX;
+    }
+}

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -8,6 +8,7 @@ import cn.nukkit.block.BlockRedstoneDiode;
 import cn.nukkit.block.GlobalBlockPalette;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.blockentity.BlockEntityChest;
+import cn.nukkit.blockentity.BlockEntityShulkerBox;
 import cn.nukkit.collection.PrimitiveList;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.entity.item.EntityItem;
@@ -1878,13 +1879,16 @@ public class Level implements ChunkManager, Metadatable {
         // Close BlockEntity before we check onBreak
         BlockEntity blockEntity = this.getBlockEntity(target);
         if (blockEntity != null) {
-            if (blockEntity instanceof InventoryHolder) {
-                if (blockEntity instanceof BlockEntityChest) {
-                    ((BlockEntityChest) blockEntity).unpair();
-                }
+            if (!(blockEntity instanceof BlockEntityShulkerBox)) //Fix shulker boxes dropping contents
+            {
+                if (blockEntity instanceof InventoryHolder) {
+                    if (blockEntity instanceof BlockEntityChest) {
+                        ((BlockEntityChest) blockEntity).unpair();
+                    }
 
-                for (Item chestItem : ((InventoryHolder) blockEntity).getInventory().getContents().values()) {
-                    this.dropItem(target, chestItem);
+                    for (Item chestItem : ((InventoryHolder) blockEntity).getInventory().getContents().values()) {
+                        this.dropItem(target, chestItem);
+                    }
                 }
             }
 

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -1879,8 +1879,8 @@ public class Level implements ChunkManager, Metadatable {
         // Close BlockEntity before we check onBreak
         BlockEntity blockEntity = this.getBlockEntity(target);
         if (blockEntity != null) {
-            if (!(blockEntity instanceof BlockEntityShulkerBox)) //Fix shulker boxes dropping contents
-            {
+            //Fix shulker boxes dropping contents
+            if (!(blockEntity instanceof BlockEntityShulkerBox)) {
                 if (blockEntity instanceof InventoryHolder) {
                     if (blockEntity instanceof BlockEntityChest) {
                         ((BlockEntityChest) blockEntity).unpair();

--- a/src/main/resources/recipes.json
+++ b/src/main/resources/recipes.json
@@ -2488,8 +2488,7 @@
       "type": 1,
       "output": [
         {
-          "id": 205,
-          "damage": 16
+          "id": 205
         }
       ],
       "shape": [


### PR DESCRIPTION
This makes shulker boxes save content and name correctly so that when it is placed again, the contents are still there.

NOTE: In order for this to work in existing servers, the recipes.json file needs to be recreated, removing damage:16 from the recipe for the shulker box due to a weird bug where it becomes unusable end stone bricks