### PR TITLE
Fix bug that can be used to slow down the server

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockCactus.java
+++ b/src/main/java/cn/nukkit/block/BlockCactus.java
@@ -134,7 +134,7 @@ public class BlockCactus extends BlockTransparentMeta {
             Block block1 = south();
             Block block2 = west();
             Block block3 = east();
-            if (block0.isTransparent() && block1.isTransparent() && block2.isTransparent() && block3.isTransparent()) {
+            if (block0.canBeFlowedInto() && block1.canBeFlowedInto() && block2.canBeFlowedInto() && block3.canBeFlowedInto()) {
                 this.getLevel().setBlock(this, this, true);
 
                 return true;


### PR DESCRIPTION
Fixed bug that made creative players possible to freeze server with cactus blocks by just holding right mouse button with cactus on hand and placing it next to other cactus