### PR TITLE
Prevent Trident Duplication

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -4636,7 +4636,6 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 Server.broadcastPacket(entity.getViewers().values(), pk);
                 this.dataPacket(pk);
 
-                this.inventory.addItem(item.clone());
                 entity.close();
                 return true;
             } else if (entity instanceof EntityItem) {


### PR DESCRIPTION
The keeping of the cloned item resulted in trident duplication (When you throw a trident to the wall and pick it up, you got two tridents)