### PR TITLE
Fires an event for Redstone

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockRedstoneDiode.java
+++ b/src/main/java/cn/nukkit/block/BlockRedstoneDiode.java
@@ -1,6 +1,7 @@
 package cn.nukkit.block;
 
 import cn.nukkit.Player;
+import cn.nukkit.event.redstone.RedstoneUpdateEvent;
 import cn.nukkit.item.Item;
 import cn.nukkit.level.Level;
 import cn.nukkit.math.BlockFace;
@@ -69,6 +70,12 @@ public abstract class BlockRedstoneDiode extends BlockFlowable {
                 }
             }
         } else if (type == Level.BLOCK_UPDATE_NORMAL || type == Level.BLOCK_UPDATE_REDSTONE) {
+            // Redstone event
+            RedstoneUpdateEvent ev = new RedstoneUpdateEvent(this);
+            getLevel().getServer().getPluginManager().callEvent(ev);
+            if (ev.isCancelled()) {
+                return 0;
+            }
             if (type == Level.BLOCK_UPDATE_NORMAL && this.getSide(BlockFace.DOWN).isTransparent()) {
                 this.level.useBreakOn(this);
                 return Level.BLOCK_UPDATE_NORMAL;

--- a/src/main/java/cn/nukkit/block/BlockRedstoneLamp.java
+++ b/src/main/java/cn/nukkit/block/BlockRedstoneLamp.java
@@ -1,6 +1,7 @@
 package cn.nukkit.block;
 
 import cn.nukkit.Player;
+import cn.nukkit.event.redstone.RedstoneUpdateEvent;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBlock;
 import cn.nukkit.item.ItemTool;
@@ -53,6 +54,12 @@ public class BlockRedstoneLamp extends BlockSolid {
     @Override
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_NORMAL || type == Level.BLOCK_UPDATE_REDSTONE) {
+            // Redstone event
+            RedstoneUpdateEvent ev = new RedstoneUpdateEvent(this);
+            getLevel().getServer().getPluginManager().callEvent(ev);
+            if (ev.isCancelled()) {
+                return 0;
+            }
             if (this.level.isBlockPowered(this)) {
                 this.level.setBlock(this, new BlockRedstoneLampLit(), false, false);
                 return 1;

--- a/src/main/java/cn/nukkit/block/BlockRedstoneLampLit.java
+++ b/src/main/java/cn/nukkit/block/BlockRedstoneLampLit.java
@@ -1,5 +1,6 @@
 package cn.nukkit.block;
 
+import cn.nukkit.event.redstone.RedstoneUpdateEvent;
 import cn.nukkit.level.Level;
 
 /**
@@ -28,6 +29,12 @@ public class BlockRedstoneLampLit extends BlockRedstoneLamp {
     @Override
     public int onUpdate(int type) {
         if ((type == Level.BLOCK_UPDATE_NORMAL || type == Level.BLOCK_UPDATE_REDSTONE) && !this.level.isBlockPowered(this)) {
+            // Redstone event
+            RedstoneUpdateEvent ev = new RedstoneUpdateEvent(this);
+            getLevel().getServer().getPluginManager().callEvent(ev);
+            if (ev.isCancelled()) {
+                return 0;
+            }
             this.level.scheduleUpdate(this, 4);
             return 1;
         }

--- a/src/main/java/cn/nukkit/block/BlockRedstoneWire.java
+++ b/src/main/java/cn/nukkit/block/BlockRedstoneWire.java
@@ -2,6 +2,7 @@ package cn.nukkit.block;
 
 import cn.nukkit.Player;
 import cn.nukkit.event.block.BlockRedstoneEvent;
+import cn.nukkit.event.redstone.RedstoneUpdateEvent;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemRedstone;
 import cn.nukkit.level.Level;
@@ -193,6 +194,12 @@ public class BlockRedstoneWire extends BlockFlowable {
     @Override
     public int onUpdate(int type) {
         if (type != Level.BLOCK_UPDATE_NORMAL && type != Level.BLOCK_UPDATE_REDSTONE) {
+            return 0;
+        }
+        // Redstone event
+        RedstoneUpdateEvent ev = new RedstoneUpdateEvent(this);
+        getLevel().getServer().getPluginManager().callEvent(ev);
+        if (ev.isCancelled()) {
             return 0;
         }
 

--- a/src/main/java/cn/nukkit/event/redstone/RedstoneUpdateEvent.java
+++ b/src/main/java/cn/nukkit/event/redstone/RedstoneUpdateEvent.java
@@ -1,6 +1,7 @@
 package cn.nukkit.event.redstone;
 
 import cn.nukkit.block.Block;
+import cn.nukkit.event.HandlerList;
 import cn.nukkit.event.block.BlockUpdateEvent;
 
 /**
@@ -8,6 +9,12 @@ import cn.nukkit.event.block.BlockUpdateEvent;
  * Nukkit Project
  */
 public class RedstoneUpdateEvent extends BlockUpdateEvent {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    public static HandlerList getHandlers() {
+        return handlers;
+    }
 
     public RedstoneUpdateEvent(Block source) {
         super(source);


### PR DESCRIPTION
Its fired when there is an update about redstone.
Basicly redstone got ticks when the redstone got an update from level.

Because of the redstone always ticking and nothing could stop it ticking,
I decided to continue the abandoned `RedstoneUpdateEvent` class by adding some 