### PR TITLE
Add Docker configuration, update README with instructions.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Jenkinsfile
+circle.yml
+README.md
+data

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ resource_packs
 resource_packs/*
 creativeitems.json
 recipes.json
+
+#Nukkit data dir
+data
+data/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# This Dockerfile uses Docker Multi-Stage Builds
+# See https://docs.docker.com/engine/userguide/eng-image/multistage-build/
+# Requires Docker v17.05
+
+# Use OpenJDK JDK image for intermiediate build
+FROM openjdk:8-jdk-slim AS build
+
+# Install packages required for build
+RUN apt update && apt install -y \
+        build-essential \
+        git \
+        maven
+
+# Build from source and create artifact
+WORKDIR /src
+COPY ./ /src
+RUN git submodule update --init
+RUN mvn clean package
+
+# Use OpenJDK JRE image for runtime
+FROM openjdk:8-jre-slim AS run
+LABEL maintainer="Micheal Waltz <dockerfiles@ecliptik.com>"
+
+# Copy artifact from build image
+COPY --from=build /src/target/nukkit-1.0-SNAPSHOT.jar /app/nukkit.jar
+
+# Create minecraft user
+RUN useradd --user-group \
+            --no-create-home \
+            --home-dir /data \
+            --shell /usr/sbin/nologin \
+            minecraft
+
+# Volumes
+VOLUME /data /home/minecraft
+
+# Ports
+EXPOSE 19132
+
+# Make app owned by minecraft user
+RUN chown -R minecraft:minecraft /app
+
+# User and group to run as
+USER minecraft:minecraft
+
+# Set runtime workdir
+WORKDIR /data
+
+# Run app
+ENTRYPOINT ["java"]
+CMD [ "-jar", "/app/nukkit.jar" ]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,29 @@ Plugin API
 -------------
 Information on Nukkit's API can be found at the [wiki](https://nukkitx.com/wiki/nukkit/).
 
+Docker
+-------------
+
+Running Nukkit in [Docker](https://www.docker.com/) (17.05+ or higher).
+
+Build image from source,
+
+```
+docker build -t nukkit .
+```
+
+Run once to generate the `/data` volume, default settings, and choose language,
+
+```
+docker run -it --rm -p 19132:19132 nukkit
+```
+
+Use [docker-compose](https://docs.docker.com/compose/overview/) to start server on port `19132` and with `./data` volume,
+
+```
+docker-compose up -d
+```
+
 Contributing
 ------------
 Please read the [CONTRIBUTING](.github/CONTRIBUTING.md) guide before submitting any issue. Issues with insufficient information or in the wrong format will be closed and will not be reviewed.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  nukkit:
+    build: ./
+    ports:
+      - "19132:19132"
+      - "19132:19132/udp"
+    volumes:
+      - ./data:/data
+    stdin_open: true
+    tty: true


### PR DESCRIPTION
Add Docker configuration for building from source and running Nukkit using a `data` volume for persistent storage.

Verified building and running locally and with Minecraft 1.6 and various plugins. Image is ~128MB in size. 

Will build and run on arm64 (Raspberry Pi 3) using Docker [multi-arch support](https://blog.docker.com/2017/09/docker-official-images-now-multi-platform/). Use `arm64` tag on Dockerhub.

[Dockerhub repository and tags](https://hub.docker.com/r/ecliptik/nukkit/tags/).

Test with Dockerhub image,

```
#Make persistent data directory
mkdir -p ./data

#Run one-time to choose language and populate defaults
docker run -it --rm  -v `pwd`/data:/data ecliptik/nukkit

#Run with docker-compose to bring up data volume and listen on port 19132
docker-compose up
```