### PR TITLE
Make ElementButton extend Element

### DIFF
--- a/src/main/java/cn/nukkit/form/element/ElementButton.java
+++ b/src/main/java/cn/nukkit/form/element/ElementButton.java
@@ -1,6 +1,6 @@
 package cn.nukkit.form.element;
 
-public class ElementButton {
+public class ElementButton extends Element {
 
     private String text = "";
     private ElementButtonImageData image;


### PR DESCRIPTION
ElementButton isn't available otherwise when creating a List<Elements> for a FormWindowCustom, fixes the issue.