### PR TITLE
Fix Container Saving

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -139,7 +139,7 @@ public class Server {
 
     private int maxPlayers;
 
-    private boolean autoSave;
+    private boolean autoSave = true;
 
     private RCON rcon;
 

--- a/src/main/java/cn/nukkit/blockentity/BlockEntity.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntity.java
@@ -10,10 +10,10 @@ import cn.nukkit.utils.ChunkException;
 import cn.nukkit.utils.MainLogger;
 import co.aikar.timings.Timing;
 import co.aikar.timings.Timings;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
 
 import java.lang.reflect.Constructor;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * @author MagicDroidX
@@ -46,8 +46,7 @@ public abstract class BlockEntity extends Position {
 
     public static long count = 1;
 
-    private static final Map<String, Class<? extends BlockEntity>> knownBlockEntities = new HashMap<>();
-    private static final Map<String, String> shortNames = new HashMap<>();
+    private static final BiMap<String, Class<? extends BlockEntity>> knownBlockEntities = HashBiMap.create(21);
 
     public FullChunk chunk;
     public String name;
@@ -137,14 +136,11 @@ public abstract class BlockEntity extends Position {
         }
 
         knownBlockEntities.put(name, c);
-        shortNames.put(c.getSimpleName(), name);
         return true;
     }
 
     public final String getSaveId() {
-        String simpleName = getClass().getName();
-        simpleName = simpleName.substring(22, simpleName.length());
-        return shortNames.getOrDefault(simpleName, "");
+        return knownBlockEntities.inverse().get(getClass());
     }
 
     public long getId() {
@@ -199,6 +195,10 @@ public abstract class BlockEntity extends Position {
 
     public void onBreak() {
 
+    }
+
+    public void setDirty() {
+        chunk.setChanged();
     }
 
     public String getName() {

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityBeacon.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityBeacon.java
@@ -3,21 +3,15 @@ package cn.nukkit.blockentity;
 import cn.nukkit.Player;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockAir;
-import cn.nukkit.event.block.SignChangeEvent;
 import cn.nukkit.inventory.BeaconInventory;
 import cn.nukkit.inventory.Inventory;
 import cn.nukkit.inventory.InventoryHolder;
-import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBlock;
 import cn.nukkit.level.format.FullChunk;
 import cn.nukkit.nbt.tag.CompoundTag;
-import cn.nukkit.nbt.tag.Tag;
 import cn.nukkit.potion.Effect;
-import cn.nukkit.scheduler.NukkitRunnable;
-import cn.nukkit.utils.TextFormat;
 
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * author: Rover656
@@ -204,7 +198,7 @@ public class BlockEntityBeacon extends BlockEntitySpawnable implements Inventory
         int currentLevel = getPowerLevel();
         if (level != currentLevel) {
             namedTag.putInt("Level", level);
-            chunk.setChanged();
+            setDirty();
             this.spawnToAll();
         }
     }
@@ -217,7 +211,7 @@ public class BlockEntityBeacon extends BlockEntitySpawnable implements Inventory
         int currentPower = getPrimaryPower();
         if (power != currentPower) {
             namedTag.putInt("Primary", power);
-            chunk.setChanged();
+            setDirty();
             this.spawnToAll();
         }
     }
@@ -230,7 +224,7 @@ public class BlockEntityBeacon extends BlockEntitySpawnable implements Inventory
         int currentPower = getSecondaryPower();
         if (power != currentPower) {
             namedTag.putInt("Secondary", power);
-            chunk.setChanged();
+            setDirty();
             this.spawnToAll();
         }
     }

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityHopper.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityHopper.java
@@ -162,7 +162,7 @@ public class BlockEntityHopper extends BlockEntitySpawnable implements Inventory
 
             if (transfer || pickup) {
                 //this.setTransferCooldown(8); TODO: maybe we should update hopper every tick if nothing happens?
-                this.chunk.setChanged(true);
+                setDirty();
             }
 
             this.setTransferCooldown(8);

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityItemFrame.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityItemFrame.java
@@ -51,7 +51,7 @@ public class BlockEntityItemFrame extends BlockEntitySpawnable {
     public void setItemRotation(int itemRotation) {
         this.namedTag.putByte("ItemRotation", itemRotation);
         this.level.updateComparatorOutputLevel(this);
-        this.setChanged();
+        this.setDirty();
     }
 
     public Item getItem() {
@@ -66,7 +66,7 @@ public class BlockEntityItemFrame extends BlockEntitySpawnable {
     public void setItem(Item item, boolean setChanged) {
         this.namedTag.putCompound("Item", NBTIO.putItemHelper(item));
         if (setChanged) {
-            this.setChanged();
+            this.setDirty();
         }
 
         this.level.updateComparatorOutputLevel(this);
@@ -80,11 +80,9 @@ public class BlockEntityItemFrame extends BlockEntitySpawnable {
         this.namedTag.putFloat("ItemDropChance", chance);
     }
 
-    private void setChanged() {
+    public void setDirty() {
         this.spawnToAll();
-        if (this.chunk != null) {
-            this.chunk.setChanged();
-        }
+        super.setDirty();
     }
 
     @Override

--- a/src/main/java/cn/nukkit/blockentity/BlockEntitySign.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntitySign.java
@@ -76,7 +76,7 @@ public class BlockEntitySign extends BlockEntitySpawnable {
         this.spawnToAll();
 
         if (this.chunk != null) {
-            this.chunk.setChanged();
+            setDirty();
         }
 
         return true;

--- a/src/main/java/cn/nukkit/inventory/BaseInventory.java
+++ b/src/main/java/cn/nukkit/inventory/BaseInventory.java
@@ -3,6 +3,7 @@ package cn.nukkit.inventory;
 import cn.nukkit.Player;
 import cn.nukkit.Server;
 import cn.nukkit.block.BlockAir;
+import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.entity.EntityInventoryChangeEvent;
 import cn.nukkit.event.inventory.InventoryOpenEvent;
@@ -157,6 +158,10 @@ public abstract class BaseInventory implements Inventory {
             }
 
             item = ev.getNewItem();
+        }
+
+        if (holder instanceof BlockEntity) {
+            ((BlockEntity) holder).setDirty();
         }
 
         Item old = this.getItem(index);
@@ -373,6 +378,9 @@ public abstract class BaseInventory implements Inventory {
                     return false;
                 }
                 item = ev.getNewItem();
+            }
+            if (holder instanceof BlockEntity) {
+                ((BlockEntity) holder).setDirty();
             }
 
             if (item.getId() != Item.AIR) {

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -198,7 +198,7 @@ public class Level implements ChunkManager, Metadatable {
     private int chunkGenerationQueueSize = 8;
     private int chunkPopulationQueueSize = 2;
 
-    private boolean autoSave = true;
+    private boolean autoSave;
 
     private BlockMetadataStore blockMetadata;
 

--- a/src/main/java/cn/nukkit/level/format/anvil/Chunk.java
+++ b/src/main/java/cn/nukkit/level/format/anvil/Chunk.java
@@ -11,7 +11,10 @@ import cn.nukkit.level.format.generic.BaseChunk;
 import cn.nukkit.level.format.generic.EmptyChunkSection;
 import cn.nukkit.nbt.NBTIO;
 import cn.nukkit.nbt.tag.*;
-import cn.nukkit.utils.*;
+import cn.nukkit.utils.BinaryStream;
+import cn.nukkit.utils.BlockUpdateEntry;
+import cn.nukkit.utils.ChunkException;
+import cn.nukkit.utils.Zlib;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -83,7 +86,7 @@ public class Chunk extends BaseChunk {
         Map<Integer, Integer> extraData = new HashMap<>();
 
         Tag extra = nbt.get("ExtraData");
-        if (extra != null && extra instanceof ByteArrayTag) {
+        if (extra instanceof ByteArrayTag) {
             BinaryStream stream = new BinaryStream(((ByteArrayTag) extra).data);
             for (int i = 0; i < stream.getInt(); i++) {
                 int key = stream.getInt();

--- a/src/main/java/cn/nukkit/level/format/generic/BaseFullChunk.java
+++ b/src/main/java/cn/nukkit/level/format/generic/BaseFullChunk.java
@@ -405,12 +405,12 @@ public abstract class BaseFullChunk implements FullChunk, ChunkManager {
 
     @Override
     public boolean unload(boolean save, boolean safe) {
-        LevelProvider level = this.getProvider();
-        if (level == null) {
+        LevelProvider provider = this.getProvider();
+        if (provider == null) {
             return true;
         }
         if (save && this.changes != 0) {
-            level.saveChunk(this.getX(), this.getZ());
+            provider.saveChunk(this.getX(), this.getZ());
         }
         if (safe) {
             for (Entity entity : this.getEntities().values()) {

--- a/src/main/java/cn/nukkit/level/format/leveldb/Chunk.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/Chunk.java
@@ -459,7 +459,7 @@ public class Chunk extends BaseFullChunk {
                 for (BlockEntity blockEntity : this.getBlockEntities().values()) {
                     if (!blockEntity.closed) {
                         blockEntity.saveNBT();
-                        entities.add(blockEntity.namedTag);
+                        tiles.add(blockEntity.namedTag);
                     }
                 }
 


### PR DESCRIPTION
Containers were not marked for saving after being modified. This fix checks if the inventory holder is instanceof `BlockEntity` and marks it as dirty