### PR TITLE
Rewrite: Add block behaviours for ores

### DIFF
--- a/api/src/main/java/com/nukkitx/api/item/TierTypes.java
+++ b/api/src/main/java/com/nukkitx/api/item/TierTypes.java
@@ -4,10 +4,10 @@ import lombok.RequiredArgsConstructor;
 
 public class TierTypes {
     public static final TierType WOOD = new IntTier(100, 2);
-    public static final TierType STONE = new IntTier(200, 4);
-    public static final TierType IRON = new IntTier(300, 6);
-    public static final TierType DIAMOND = new IntTier(400, 8);
-    public static final TierType GOLD = new IntTier(500, 12);
+    public static final TierType GOLD = new IntTier(200, 12);
+    public static final TierType STONE = new IntTier(300, 4);
+    public static final TierType IRON = new IntTier(400, 6);
+    public static final TierType DIAMOND = new IntTier(500, 8);
 
     @RequiredArgsConstructor
     private static class IntTier implements TierType {

--- a/server/src/main/java/com/nukkitx/server/block/behavior/BlockBehaviors.java
+++ b/server/src/main/java/com/nukkitx/server/block/behavior/BlockBehaviors.java
@@ -16,6 +16,14 @@ public class BlockBehaviors {
         BLOCK_BEHAVIORS = ImmutableMap.<BlockType, BlockBehavior>builder()
                 .put(BlockTypes.DIRT, DirtBlockBehavior.INSTANCE)
                 .put(BlockTypes.GRASS_BLOCK, DirtBlockBehavior.INSTANCE)
+                .put(BlockTypes.COAL_ORE, CoalOreBlockBehavior.INSTANCE)
+                .put(BlockTypes.DIAMOND_BLOCK, DiamondOreBlockBehavior.INSTANCE)
+                .put(BlockTypes.EMERALD_ORE, EmeraldOreBlockBehavior.INSTANCE)
+                .put(BlockTypes.GOLD_ORE, GoldOreBlockBehavior.INSTANCE)
+                .put(BlockTypes.IRON_ORE, IronOreBlockBehavior.INSTANCE)
+                .put(BlockTypes.LAPIS_LAZULI_ORE, LapisLazuliOreBlockBehavior.INSTANCE)
+                .put(BlockTypes.NETHER_QUARTZ_ORE, NetherQuartzOreBlockBehavior.INSTANCE)
+                .put(BlockTypes.REDSTONE_ORE, RedstoneOreBlockBehavior.INSTANCE)
                 .build();
     }
 

--- a/server/src/main/java/com/nukkitx/server/block/behavior/CoalOreBlockBehavior.java
+++ b/server/src/main/java/com/nukkitx/server/block/behavior/CoalOreBlockBehavior.java
@@ -1,0 +1,28 @@
+package com.nukkitx.server.block.behavior;
+
+import com.google.common.collect.ImmutableList;
+import com.nukkitx.api.Player;
+import com.nukkitx.api.block.Block;
+import com.nukkitx.api.item.ItemInstance;
+import com.nukkitx.api.item.ItemTypes;
+import com.nukkitx.api.item.ToolTypes;
+import com.nukkitx.server.item.NukkitItemInstanceBuilder;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+public class CoalOreBlockBehavior extends SimpleBlockBehavior {
+    public static final CoalOreBlockBehavior INSTANCE = new CoalOreBlockBehavior();
+    private static final ItemInstance COAL = new NukkitItemInstanceBuilder().itemType(ItemTypes.COAL).amount(1).build();
+
+    @Override
+    public Collection<ItemInstance> getDrops(Player player, Block block, @Nullable ItemInstance item) {
+        return ImmutableList.of(COAL);
+    }
+
+    @Override
+    public boolean isCorrectTool(@Nullable ItemInstance item) {
+        return item != null && item.getItemType().getToolType().isPresent() &&
+                item.getItemType().getToolType().get() == ToolTypes.PICKAXE;
+    }
+}

--- a/server/src/main/java/com/nukkitx/server/block/behavior/DiamondOreBlockBehavior.java
+++ b/server/src/main/java/com/nukkitx/server/block/behavior/DiamondOreBlockBehavior.java
@@ -18,7 +18,7 @@ public class DiamondOreBlockBehavior extends SimpleBlockBehavior {
 
     @Override
     public Collection<ItemInstance> getDrops(Player player, Block block, @Nullable ItemInstance item) {
-        if(isCorrectTool(item)) {
+        if(isCorrectTool(   item)) {
             return ImmutableList.of(DIAMOND);
         }
         return ImmutableList.of();

--- a/server/src/main/java/com/nukkitx/server/block/behavior/DiamondOreBlockBehavior.java
+++ b/server/src/main/java/com/nukkitx/server/block/behavior/DiamondOreBlockBehavior.java
@@ -18,7 +18,7 @@ public class DiamondOreBlockBehavior extends SimpleBlockBehavior {
 
     @Override
     public Collection<ItemInstance> getDrops(Player player, Block block, @Nullable ItemInstance item) {
-        if(isCorrectTool(   item)) {
+        if(isCorrectTool(item)) {
             return ImmutableList.of(DIAMOND);
         }
         return ImmutableList.of();

--- a/server/src/main/java/com/nukkitx/server/block/behavior/DiamondOreBlockBehavior.java
+++ b/server/src/main/java/com/nukkitx/server/block/behavior/DiamondOreBlockBehavior.java
@@ -1,0 +1,34 @@
+package com.nukkitx.server.block.behavior;
+
+import com.google.common.collect.ImmutableList;
+import com.nukkitx.api.Player;
+import com.nukkitx.api.block.Block;
+import com.nukkitx.api.item.ItemInstance;
+import com.nukkitx.api.item.ItemTypes;
+import com.nukkitx.api.item.TierTypes;
+import com.nukkitx.api.item.ToolTypes;
+import com.nukkitx.server.item.NukkitItemInstanceBuilder;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+public class DiamondOreBlockBehavior extends SimpleBlockBehavior {
+    public static final DiamondOreBlockBehavior INSTANCE = new DiamondOreBlockBehavior();
+    private static final ItemInstance DIAMOND = new NukkitItemInstanceBuilder().itemType(ItemTypes.DIAMOND).amount(1).build();
+
+    @Override
+    public Collection<ItemInstance> getDrops(Player player, Block block, @Nullable ItemInstance item) {
+        if(isCorrectTool(item)) {
+            return ImmutableList.of(DIAMOND);
+        }
+        return ImmutableList.of();
+    }
+
+    @Override
+    public boolean isCorrectTool(@Nullable ItemInstance item) {
+        return item != null && item.getItemType().getToolType().isPresent() &&
+                item.getItemType().getToolType().get() == ToolTypes.PICKAXE &&
+                item.getItemType().getTierType().isPresent() &&
+                item.getItemType().getTierType().get().getLevel() >= TierTypes.IRON.getLevel();
+    }
+}

--- a/server/src/main/java/com/nukkitx/server/block/behavior/EmeraldOreBlockBehavior.java
+++ b/server/src/main/java/com/nukkitx/server/block/behavior/EmeraldOreBlockBehavior.java
@@ -26,7 +26,6 @@ public class EmeraldOreBlockBehavior extends SimpleBlockBehavior {
         return item != null && item.getItemType().getToolType().isPresent() &&
                 item.getItemType().getToolType().get() == ToolTypes.PICKAXE &&
                 item.getItemType().getTierType().isPresent() &&
-                (item.getItemType().getTierType().get() == TierTypes.IRON ||
-                        item.getItemType().getTierType().get() == TierTypes.DIAMOND);
+                item.getItemType().getTierType().get().getLevel() >= TierTypes.IRON.getLevel();
     }
 }

--- a/server/src/main/java/com/nukkitx/server/block/behavior/EmeraldOreBlockBehavior.java
+++ b/server/src/main/java/com/nukkitx/server/block/behavior/EmeraldOreBlockBehavior.java
@@ -1,0 +1,32 @@
+package com.nukkitx.server.block.behavior;
+
+import com.google.common.collect.ImmutableList;
+import com.nukkitx.api.Player;
+import com.nukkitx.api.block.Block;
+import com.nukkitx.api.item.ItemInstance;
+import com.nukkitx.api.item.ItemTypes;
+import com.nukkitx.api.item.TierTypes;
+import com.nukkitx.api.item.ToolTypes;
+import com.nukkitx.server.item.NukkitItemInstanceBuilder;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+public class EmeraldOreBlockBehavior extends SimpleBlockBehavior {
+    public static final EmeraldOreBlockBehavior INSTANCE = new EmeraldOreBlockBehavior();
+    private static final ItemInstance EMERALD = new NukkitItemInstanceBuilder().itemType(ItemTypes.EMERALD).amount(1).build();
+
+    @Override
+    public Collection<ItemInstance> getDrops(Player player, Block block, @Nullable ItemInstance item) {
+        return ImmutableList.of(EMERALD);
+    }
+
+    @Override
+    public boolean isCorrectTool(@Nullable ItemInstance item) {
+        return item != null && item.getItemType().getToolType().isPresent() &&
+                item.getItemType().getToolType().get() == ToolTypes.PICKAXE &&
+                item.getItemType().getTierType().isPresent() &&
+                (item.getItemType().getTierType().get() == TierTypes.IRON ||
+                        item.getItemType().getTierType().get() == TierTypes.DIAMOND);
+    }
+}

--- a/server/src/main/java/com/nukkitx/server/block/behavior/GoldOreBlockBehavior.java
+++ b/server/src/main/java/com/nukkitx/server/block/behavior/GoldOreBlockBehavior.java
@@ -1,0 +1,32 @@
+package com.nukkitx.server.block.behavior;
+
+import com.google.common.collect.ImmutableList;
+import com.nukkitx.api.Player;
+import com.nukkitx.api.block.Block;
+import com.nukkitx.api.block.BlockTypes;
+import com.nukkitx.api.item.ItemInstance;
+import com.nukkitx.api.item.TierTypes;
+import com.nukkitx.api.item.ToolTypes;
+import com.nukkitx.server.item.NukkitItemInstanceBuilder;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+public class GoldOreBlockBehavior extends SimpleBlockBehavior {
+    public static final GoldOreBlockBehavior INSTANCE = new GoldOreBlockBehavior();
+    private static final ItemInstance GOLD_ORE = new NukkitItemInstanceBuilder().itemType(BlockTypes.GOLD_ORE).amount(1).build();
+
+    @Override
+    public Collection<ItemInstance> getDrops(Player player, Block block, @Nullable ItemInstance item) {
+        return ImmutableList.of(GOLD_ORE);
+    }
+
+    @Override
+    public boolean isCorrectTool(@Nullable ItemInstance item) {
+        return item != null && item.getItemType().getToolType().isPresent() &&
+                item.getItemType().getToolType().get() == ToolTypes.PICKAXE &&
+                item.getItemType().getTierType().isPresent() &&
+                (item.getItemType().getTierType().get() == TierTypes.IRON ||
+                        item.getItemType().getTierType().get() == TierTypes.DIAMOND);
+    }
+}

--- a/server/src/main/java/com/nukkitx/server/block/behavior/GoldOreBlockBehavior.java
+++ b/server/src/main/java/com/nukkitx/server/block/behavior/GoldOreBlockBehavior.java
@@ -26,7 +26,6 @@ public class GoldOreBlockBehavior extends SimpleBlockBehavior {
         return item != null && item.getItemType().getToolType().isPresent() &&
                 item.getItemType().getToolType().get() == ToolTypes.PICKAXE &&
                 item.getItemType().getTierType().isPresent() &&
-                (item.getItemType().getTierType().get() == TierTypes.IRON ||
-                        item.getItemType().getTierType().get() == TierTypes.DIAMOND);
+                item.getItemType().getTierType().get().getLevel() >= TierTypes.IRON.getLevel();
     }
 }

--- a/server/src/main/java/com/nukkitx/server/block/behavior/IronOreBlockBehavior.java
+++ b/server/src/main/java/com/nukkitx/server/block/behavior/IronOreBlockBehavior.java
@@ -26,8 +26,6 @@ public class IronOreBlockBehavior extends SimpleBlockBehavior {
         return item != null && item.getItemType().getToolType().isPresent() &&
                 item.getItemType().getToolType().get() == ToolTypes.PICKAXE &&
                 item.getItemType().getTierType().isPresent() &&
-                (item.getItemType().getTierType().get() == TierTypes.STONE ||
-                        item.getItemType().getTierType().get() == TierTypes.IRON ||
-                        item.getItemType().getTierType().get() == TierTypes.DIAMOND);
+                item.getItemType().getTierType().get().getLevel() >= TierTypes.STONE.getLevel();
     }
 }

--- a/server/src/main/java/com/nukkitx/server/block/behavior/IronOreBlockBehavior.java
+++ b/server/src/main/java/com/nukkitx/server/block/behavior/IronOreBlockBehavior.java
@@ -1,0 +1,33 @@
+package com.nukkitx.server.block.behavior;
+
+import com.google.common.collect.ImmutableList;
+import com.nukkitx.api.Player;
+import com.nukkitx.api.block.Block;
+import com.nukkitx.api.block.BlockTypes;
+import com.nukkitx.api.item.ItemInstance;
+import com.nukkitx.api.item.TierTypes;
+import com.nukkitx.api.item.ToolTypes;
+import com.nukkitx.server.item.NukkitItemInstanceBuilder;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+public class IronOreBlockBehavior extends SimpleBlockBehavior {
+    public static final IronOreBlockBehavior INSTANCE = new IronOreBlockBehavior();
+    private static final ItemInstance IRON_ORE = new NukkitItemInstanceBuilder().itemType(BlockTypes.IRON_ORE).amount(1).build();
+
+    @Override
+    public Collection<ItemInstance> getDrops(Player player, Block block, @Nullable ItemInstance item) {
+        return ImmutableList.of(IRON_ORE);
+    }
+
+    @Override
+    public boolean isCorrectTool(@Nullable ItemInstance item) {
+        return item != null && item.getItemType().getToolType().isPresent() &&
+                item.getItemType().getToolType().get() == ToolTypes.PICKAXE &&
+                item.getItemType().getTierType().isPresent() &&
+                (item.getItemType().getTierType().get() == TierTypes.STONE ||
+                        item.getItemType().getTierType().get() == TierTypes.IRON ||
+                        item.getItemType().getTierType().get() == TierTypes.DIAMOND);
+    }
+}

--- a/server/src/main/java/com/nukkitx/server/block/behavior/LapisLazuliOreBlockBehavior.java
+++ b/server/src/main/java/com/nukkitx/server/block/behavior/LapisLazuliOreBlockBehavior.java
@@ -1,0 +1,39 @@
+package com.nukkitx.server.block.behavior;
+
+import com.google.common.collect.ImmutableList;
+import com.nukkitx.api.Player;
+import com.nukkitx.api.block.Block;
+import com.nukkitx.api.item.ItemInstance;
+import com.nukkitx.api.item.ItemTypes;
+import com.nukkitx.api.item.TierTypes;
+import com.nukkitx.api.item.ToolTypes;
+import com.nukkitx.api.metadata.Dyed;
+import com.nukkitx.api.metadata.data.DyeColor;
+import com.nukkitx.server.item.NukkitItemInstanceBuilder;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class LapisLazuliOreBlockBehavior extends SimpleBlockBehavior {
+    public static final LapisLazuliOreBlockBehavior INSTANCE = new LapisLazuliOreBlockBehavior();
+    private static final ThreadLocalRandom RANDOM = ThreadLocalRandom.current();
+    private static final ItemInstance LAPIS = new NukkitItemInstanceBuilder().itemType(ItemTypes.DYE)
+            .itemData(Dyed.of(DyeColor.BLUE)).amount(4 + RANDOM.nextInt(5)).build();
+
+    @Override
+    public Collection<ItemInstance> getDrops(Player player, Block block, @Nullable ItemInstance item) {
+        if(isCorrectTool(item)) {
+            return ImmutableList.of(LAPIS);
+        }
+        return ImmutableList.of();
+    }
+
+    @Override
+    public boolean isCorrectTool(@Nullable ItemInstance item) {
+        return item != null && item.getItemType().getToolType().isPresent() &&
+                item.getItemType().getToolType().get() == ToolTypes.PICKAXE &&
+                item.getItemType().getTierType().isPresent() &&
+                item.getItemType().getTierType().get() != TierTypes.WOOD;
+    }
+}

--- a/server/src/main/java/com/nukkitx/server/block/behavior/LapisLazuliOreBlockBehavior.java
+++ b/server/src/main/java/com/nukkitx/server/block/behavior/LapisLazuliOreBlockBehavior.java
@@ -34,6 +34,6 @@ public class LapisLazuliOreBlockBehavior extends SimpleBlockBehavior {
         return item != null && item.getItemType().getToolType().isPresent() &&
                 item.getItemType().getToolType().get() == ToolTypes.PICKAXE &&
                 item.getItemType().getTierType().isPresent() &&
-                item.getItemType().getTierType().get() != TierTypes.WOOD;
+                item.getItemType().getTierType().get().getLevel() >= TierTypes.STONE.getLevel();
     }
 }

--- a/server/src/main/java/com/nukkitx/server/block/behavior/NetherQuartzOreBlockBehavior.java
+++ b/server/src/main/java/com/nukkitx/server/block/behavior/NetherQuartzOreBlockBehavior.java
@@ -1,0 +1,28 @@
+package com.nukkitx.server.block.behavior;
+
+import com.google.common.collect.ImmutableList;
+import com.nukkitx.api.Player;
+import com.nukkitx.api.block.Block;
+import com.nukkitx.api.item.ItemInstance;
+import com.nukkitx.api.item.ItemTypes;
+import com.nukkitx.api.item.ToolTypes;
+import com.nukkitx.server.item.NukkitItemInstanceBuilder;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+public class NetherQuartzOreBlockBehavior extends SimpleBlockBehavior {
+    public static final NetherQuartzOreBlockBehavior INSTANCE = new NetherQuartzOreBlockBehavior();
+    private static final ItemInstance NETHER_QUARTZ = new NukkitItemInstanceBuilder().itemType(ItemTypes.NETHER_QUARTZ).amount(1).build();
+
+    @Override
+    public Collection<ItemInstance> getDrops(Player player, Block block, @Nullable ItemInstance item) {
+        return ImmutableList.of(NETHER_QUARTZ);
+    }
+
+    @Override
+    public boolean isCorrectTool(@Nullable ItemInstance item) {
+        return item != null && item.getItemType().getToolType().isPresent() &&
+                item.getItemType().getToolType().get() == ToolTypes.PICKAXE;
+    }
+}

--- a/server/src/main/java/com/nukkitx/server/block/behavior/RedstoneOreBlockBehavior.java
+++ b/server/src/main/java/com/nukkitx/server/block/behavior/RedstoneOreBlockBehavior.java
@@ -1,0 +1,40 @@
+package com.nukkitx.server.block.behavior;
+
+import com.google.common.collect.ImmutableList;
+import com.nukkitx.api.Player;
+import com.nukkitx.api.block.Block;
+import com.nukkitx.api.item.ItemInstance;
+import com.nukkitx.api.item.ItemTypes;
+import com.nukkitx.api.item.TierTypes;
+import com.nukkitx.api.item.ToolTypes;
+import com.nukkitx.api.metadata.Dyed;
+import com.nukkitx.api.metadata.data.DyeColor;
+import com.nukkitx.server.item.NukkitItemInstanceBuilder;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class RedstoneOreBlockBehavior extends SimpleBlockBehavior {
+    public static final RedstoneOreBlockBehavior INSTANCE = new RedstoneOreBlockBehavior();
+    private static final ThreadLocalRandom RANDOM = ThreadLocalRandom.current();
+    private static final ItemInstance REDSTONE = new NukkitItemInstanceBuilder().itemType(ItemTypes.REDSTONE)
+            .amount(4 + RANDOM.nextInt(2)).build();
+
+    @Override
+    public Collection<ItemInstance> getDrops(Player player, Block block, @Nullable ItemInstance item) {
+        if(isCorrectTool(item)) {
+            return ImmutableList.of(REDSTONE);
+        }
+        return ImmutableList.of();
+    }
+
+    @Override
+    public boolean isCorrectTool(@Nullable ItemInstance item) {
+        return item != null && item.getItemType().getToolType().isPresent() &&
+                item.getItemType().getToolType().get() == ToolTypes.PICKAXE &&
+                item.getItemType().getTierType().isPresent() &&
+                (item.getItemType().getTierType().get() != TierTypes.IRON ||
+                        item.getItemType().getTierType().get() != TierTypes.DIAMOND);
+    }
+}

--- a/server/src/main/java/com/nukkitx/server/block/behavior/RedstoneOreBlockBehavior.java
+++ b/server/src/main/java/com/nukkitx/server/block/behavior/RedstoneOreBlockBehavior.java
@@ -34,7 +34,6 @@ public class RedstoneOreBlockBehavior extends SimpleBlockBehavior {
         return item != null && item.getItemType().getToolType().isPresent() &&
                 item.getItemType().getToolType().get() == ToolTypes.PICKAXE &&
                 item.getItemType().getTierType().isPresent() &&
-                (item.getItemType().getTierType().get() != TierTypes.IRON ||
-                        item.getItemType().getTierType().get() != TierTypes.DIAMOND);
+                item.getItemType().getTierType().get().getLevel() >= TierTypes.IRON.getLevel();
     }
 }


### PR DESCRIPTION
This pull requests adds the (hopefully) correct drops for all of the ores in the game.

### Follow up
I think behaviour classes for the following circumstances should be added:
* Blocks that drop a different item ([reference](https://github.com/voxelwind/voxelwind/blob/master/server/src/main/java/com/voxelwind/server/game/level/block/behaviors/DropOtherItemBlockBehavior.java))
* Possibly for blocks that drop themselves (unless theres already a way that can be implemented)

---

I'm not quite sure if this will work since i obviously cant test it in game, but it compiles at least.