### PR TITLE
Fixed blocks disappear if you're "fast bridging"

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -1829,7 +1829,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     }
 
     public boolean canInteract(Vector3 pos, double maxDistance) {
-        return this.canInteract(pos, maxDistance, 0.5);
+        return this.canInteract(pos, maxDistance, 0.6);
     }
 
     public boolean canInteract(Vector3 pos, double maxDistance, double maxDiff) {


### PR DESCRIPTION
Changed the maxDiff of the Level#canInteract method to 0.6 as 0.5 leaded to a glitch where blocks sometimes just disappear if players are "fast bridging" even though they have a good ping.