### PR TITLE
Register Pillager and Wandering Trader IDs to AddEntityPacket

### DIFF
--- a/src/main/java/cn/nukkit/network/protocol/AddEntityPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/AddEntityPacket.java
@@ -119,6 +119,8 @@ public class AddEntityPacket extends DataPacket {
             .put(106, "minecraft:ice_bomb")
             .put(EntityPhantom.NETWORK_ID, "minecraft:phantom")
             .put(62, "minecraft:tripod_camera")
+            .put(114, "minecraft:pillager")
+            .put(118, "minecraft:wandering_trader")
             .build();
 
     @Override


### PR DESCRIPTION
Registering these is needed so plugins like Mob Plugin can spawn them without crashing the server