### PR TITLE
Fix Infinite health (absorption heart) glitch

### DIFF
--- a/src/main/java/cn/nukkit/entity/EntityHumanType.java
+++ b/src/main/java/cn/nukkit/entity/EntityHumanType.java
@@ -138,8 +138,7 @@ public abstract class EntityHumanType extends EntityCreature implements Inventor
 
             float finalDamage = (float) (originalDamage * (1 - Math.max(points / 5f, points - originalDamage / (2 + toughness / 4f)) / 25) * (1 - /*0.75 */ epf * 0.04));
 
-            source.setDamage(finalDamage - originalDamage, DamageModifier.ARMOR);
-            //source.setDamage(source.getDamage(DamageModifier.ARMOR_ENCHANTMENTS) - (originalDamage - originalDamage * (1 - epf / 25)), DamageModifier.ARMOR_ENCHANTMENTS);
+            source.setDamage(originalDamage - finalDamage, DamageModifier.ARMOR);
         }
 
         if (super.attack(source)) {


### PR DESCRIPTION
Fix the glitch where if you have absorption effect on, any projectile attack, explosion attack, and fall damage on you will give you a more than the usual amount of absorption hearts.