### PR TITLE
Reduce TNT and End Crystal Explosion power

### DIFF
--- a/src/main/java/cn/nukkit/level/Explosion.java
+++ b/src/main/java/cn/nukkit/level/Explosion.java
@@ -150,7 +150,7 @@ public class Explosion {
                 Vector3 motion = entity.subtract(this.source).normalize();
                 int exposure = 1;
                 double impact = (1 - distance) * exposure;
-                int damage = (int) (((impact * impact + impact) / 2) * 8 * explosionSize + 1);
+                int damage = (int) (((impact * impact + impact) / 10) * 2 * explosionSize + 1);
 
                 if (this.what instanceof Entity) {
                     entity.attack(new EntityDamageByEntityEvent((Entity) this.what, entity, DamageCause.ENTITY_EXPLOSION, damage));


### PR DESCRIPTION
The explosion damage is too high, in nukkit, a tnt or an end crystal can instant kill someone wearing full diamond standing next to the bomb, even if he ate a god apple. But in vanilla, tnt or crystal explosion only take away two hearts from a player