### PR TITLE
Fix: Brewing stand fuel slot content is lost when the entity is reloaded

### DIFF
--- a/src/main/java/cn/nukkit/blockentity/BlockEntityBrewingStand.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityBrewingStand.java
@@ -128,7 +128,7 @@ public class BlockEntityBrewingStand extends BlockEntitySpawnable implements Inv
 
     @Override
     public int getSize() {
-        return 4;
+        return 5;
     }
 
     protected int getSlotIndex(int index) {


### PR DESCRIPTION
The brewing stand tile entity's inventory size were incorrect so the blaze powder disappears when the chunk is reloaded.