### PR TITLE
Allows for CustomItemBlocks

### DIFF
--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -306,8 +306,8 @@ public class Item implements Cloneable, BlockID, ItemID {
         initCreativeItems();
     }
 
-    private static void registerCustomItemBlock(ItemBlock i) {
-        customlist[i.getId()] = i.getClass();
+    public static void registerCustomItemBlock(int key, Class i) {
+        customlist[key] = i;
     }
 
     @SuppressWarnings("unchecked")
@@ -400,7 +400,15 @@ public class Item implements Cloneable, BlockID, ItemID {
                         item = new ItemBlock(Block.get(id), meta, count);
                     }
                 } else {
-                    item = ((ItemBlock) customlist[id].getConstructor(Integer.class, int.class).newInstance(meta, count));
+                   try{
+                    item = ((ItemBlock) customlist[id].getConstructor(Block.class, Integer.class, int.class).newInstance(Block.get(id, meta), meta, count));
+                }catch (Exception e){
+                       if (meta >= 0) {
+                           item = new ItemBlock(Block.get(id, meta), meta, count);
+                       } else {
+                           item = new ItemBlock(Block.get(id), meta, count);
+                       }
+                   }
                 }
             } else {
                 item = ((Item) c.getConstructor(Integer.class, int.class).newInstance(meta, count));


### PR DESCRIPTION
I noticed that whenever a Block is broken or given, The resulting Item is converted to ItemBlocks and I have loads of Custom Blocks so keeping data between a player Placing the ItemBlock with Custom Nametag (My way to keep Data in a ItemBlock) and then a Player Breaking a Custom Block with a Block entity (My way of saving data for a Block) and Dropping the correct Item with the Correct data. Sure I can change the Dropped Item in my custom item block but when I do so, as soon as the server restarts or reloads the ItemBlock somehow gets converted to an Item! NOT an ITEMBLOCK as it should. This should allow developers the oppotunity to set custom names and Other Data as a Class that extends ItemBlock and allow for other data to be stored and converted safely from a ItemBlock to a Block! Also when using the /give command your custom Item Block will also be given. No more Unknow Item or Items with default names.

