### PR TITLE
Fix isNameTagAlwaysVisible() giving wrong result

### DIFF
--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -489,7 +489,7 @@ public abstract class Entity extends Location implements Metadatable {
     }
 
     public boolean isNameTagAlwaysVisible() {
-        return this.getDataFlag(DATA_FLAGS, DATA_FLAG_ALWAYS_SHOW_NAMETAG);
+        return this.getDataPropertyByte(DATA_ALWAYS_SHOW_NAMETAG) == 1;
     }
 
     public void setNameTag(String name) {


### PR DESCRIPTION
Since `setNameTagAlwaysVisible()` edits **property** instead of **flag**, the `isNameTagAlwaysVisible()` also should check for **property**, not **flag**