### PR TITLE
BlockFadeEvent

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockFire.java
+++ b/src/main/java/cn/nukkit/block/BlockFire.java
@@ -5,6 +5,7 @@ import cn.nukkit.Server;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.entity.projectile.EntityArrow;
 import cn.nukkit.event.block.BlockBurnEvent;
+import cn.nukkit.event.block.BlockFadeEvent;
 import cn.nukkit.event.block.BlockIgniteEvent;
 import cn.nukkit.event.entity.EntityCombustByBlockEvent;
 import cn.nukkit.event.entity.EntityDamageByBlockEvent;
@@ -91,7 +92,11 @@ public class BlockFire extends BlockFlowable {
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_NORMAL || type == Level.BLOCK_UPDATE_RANDOM) {
             if (!this.isBlockTopFacingSurfaceSolid(this.down()) && !this.canNeighborBurn()) {
-                this.getLevel().setBlock(this, new BlockAir(), true);
+                BlockFadeEvent event = new BlockFadeEvent(this, get(AIR));
+                level.getServer().getPluginManager().callEvent(event);
+                if (!event.isCancelled()) {
+                    level.setBlock(this, event.getNewBlock(), true);
+                }
             }
 
             return Level.BLOCK_UPDATE_NORMAL;
@@ -103,7 +108,11 @@ public class BlockFire extends BlockFlowable {
             //TODO: END
 
             if (!this.isBlockTopFacingSurfaceSolid(this.down()) && !this.canNeighborBurn()) {
-                this.getLevel().setBlock(this, new BlockAir(), true);
+                BlockFadeEvent event = new BlockFadeEvent(this, get(AIR));
+                level.getServer().getPluginManager().callEvent(event);
+                if (!event.isCancelled()) {
+                    level.setBlock(this, event.getNewBlock(), true);
+                }
             }
 
             if (!forever && this.getLevel().isRaining() &&
@@ -113,7 +122,11 @@ public class BlockFire extends BlockFlowable {
                             this.getLevel().canBlockSeeSky(this.south()) ||
                             this.getLevel().canBlockSeeSky(this.north()))
                     ) {
-                this.getLevel().setBlock(this, new BlockAir(), true);
+                BlockFadeEvent event = new BlockFadeEvent(this, get(AIR));
+                level.getServer().getPluginManager().callEvent(event);
+                if (!event.isCancelled()) {
+                    level.setBlock(this, event.getNewBlock(), true);
+                }
             } else {
                 int meta = this.getDamage();
 
@@ -127,10 +140,18 @@ public class BlockFire extends BlockFlowable {
 
                 if (!forever && !this.canNeighborBurn()) {
                     if (!this.isBlockTopFacingSurfaceSolid(this.down()) || meta > 3) {
-                        this.getLevel().setBlock(this, new BlockAir(), true);
+                        BlockFadeEvent event = new BlockFadeEvent(this, get(AIR));
+                        level.getServer().getPluginManager().callEvent(event);
+                        if (!event.isCancelled()) {
+                            level.setBlock(this, event.getNewBlock(), true);
+                        }
                     }
                 } else if (!forever && !(this.down().getBurnAbility() > 0) && meta == 15 && random.nextInt(4) == 0) {
-                    this.getLevel().setBlock(this, new BlockAir(), true);
+                    BlockFadeEvent event = new BlockFadeEvent(this, get(AIR));
+                    level.getServer().getPluginManager().callEvent(event);
+                    if (!event.isCancelled()) {
+                        level.setBlock(this, event.getNewBlock(), true);
+                    }
                 } else {
                     int o = 0;
 

--- a/src/main/java/cn/nukkit/block/BlockFire.java
+++ b/src/main/java/cn/nukkit/block/BlockFire.java
@@ -95,7 +95,7 @@ public class BlockFire extends BlockFlowable {
                 BlockFadeEvent event = new BlockFadeEvent(this, get(AIR));
                 level.getServer().getPluginManager().callEvent(event);
                 if (!event.isCancelled()) {
-                    level.setBlock(this, event.getNewBlock(), true);
+                    level.setBlock(this, event.getNewState(), true);
                 }
             }
 
@@ -111,7 +111,7 @@ public class BlockFire extends BlockFlowable {
                 BlockFadeEvent event = new BlockFadeEvent(this, get(AIR));
                 level.getServer().getPluginManager().callEvent(event);
                 if (!event.isCancelled()) {
-                    level.setBlock(this, event.getNewBlock(), true);
+                    level.setBlock(this, event.getNewState(), true);
                 }
             }
 
@@ -125,7 +125,7 @@ public class BlockFire extends BlockFlowable {
                 BlockFadeEvent event = new BlockFadeEvent(this, get(AIR));
                 level.getServer().getPluginManager().callEvent(event);
                 if (!event.isCancelled()) {
-                    level.setBlock(this, event.getNewBlock(), true);
+                    level.setBlock(this, event.getNewState(), true);
                 }
             } else {
                 int meta = this.getDamage();
@@ -143,14 +143,14 @@ public class BlockFire extends BlockFlowable {
                         BlockFadeEvent event = new BlockFadeEvent(this, get(AIR));
                         level.getServer().getPluginManager().callEvent(event);
                         if (!event.isCancelled()) {
-                            level.setBlock(this, event.getNewBlock(), true);
+                            level.setBlock(this, event.getNewState(), true);
                         }
                     }
                 } else if (!forever && !(this.down().getBurnAbility() > 0) && meta == 15 && random.nextInt(4) == 0) {
                     BlockFadeEvent event = new BlockFadeEvent(this, get(AIR));
                     level.getServer().getPluginManager().callEvent(event);
                     if (!event.isCancelled()) {
-                        level.setBlock(this, event.getNewBlock(), true);
+                        level.setBlock(this, event.getNewState(), true);
                     }
                 } else {
                     int o = 0;

--- a/src/main/java/cn/nukkit/block/BlockIce.java
+++ b/src/main/java/cn/nukkit/block/BlockIce.java
@@ -1,5 +1,6 @@
 package cn.nukkit.block;
 
+import cn.nukkit.event.block.BlockFadeEvent;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemTool;
 import cn.nukkit.level.Level;
@@ -54,7 +55,11 @@ public class BlockIce extends BlockTransparent {
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_RANDOM) {
             if (this.getLevel().getBlockLightAt((int) this.x, (int) this.y, (int) this.z) >= 12) {
-                this.getLevel().setBlock(this, new BlockWater(), true);
+                BlockFadeEvent event = new BlockFadeEvent(this, get(WATER));
+                level.getServer().getPluginManager().callEvent(event);
+                if (!event.isCancelled()) {
+                    level.setBlock(this, event.getNewBlock(), true);
+                }
                 return Level.BLOCK_UPDATE_NORMAL;
             }
         }

--- a/src/main/java/cn/nukkit/block/BlockIce.java
+++ b/src/main/java/cn/nukkit/block/BlockIce.java
@@ -58,7 +58,7 @@ public class BlockIce extends BlockTransparent {
                 BlockFadeEvent event = new BlockFadeEvent(this, get(WATER));
                 level.getServer().getPluginManager().callEvent(event);
                 if (!event.isCancelled()) {
-                    level.setBlock(this, event.getNewBlock(), true);
+                    level.setBlock(this, event.getNewState(), true);
                 }
                 return Level.BLOCK_UPDATE_NORMAL;
             }

--- a/src/main/java/cn/nukkit/block/BlockOreRedstoneGlowing.java
+++ b/src/main/java/cn/nukkit/block/BlockOreRedstoneGlowing.java
@@ -1,5 +1,6 @@
 package cn.nukkit.block;
 
+import cn.nukkit.event.block.BlockFadeEvent;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBlock;
 import cn.nukkit.level.Level;
@@ -38,7 +39,11 @@ public class BlockOreRedstoneGlowing extends BlockOreRedstone {
     @Override
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_SCHEDULED || type == Level.BLOCK_UPDATE_RANDOM) {
-            this.getLevel().setBlock(this, new BlockOreRedstone(), false, false);
+            BlockFadeEvent event = new BlockFadeEvent(this, get(REDSTONE_ORE));
+            level.getServer().getPluginManager().callEvent(event);
+            if (!event.isCancelled()) {
+                level.setBlock(this, event.getNewBlock(), false, false);
+            }
 
             return Level.BLOCK_UPDATE_WEAK;
         }

--- a/src/main/java/cn/nukkit/block/BlockOreRedstoneGlowing.java
+++ b/src/main/java/cn/nukkit/block/BlockOreRedstoneGlowing.java
@@ -42,7 +42,7 @@ public class BlockOreRedstoneGlowing extends BlockOreRedstone {
             BlockFadeEvent event = new BlockFadeEvent(this, get(REDSTONE_ORE));
             level.getServer().getPluginManager().callEvent(event);
             if (!event.isCancelled()) {
-                level.setBlock(this, event.getNewBlock(), false, false);
+                level.setBlock(this, event.getNewState(), false, false);
             }
 
             return Level.BLOCK_UPDATE_WEAK;

--- a/src/main/java/cn/nukkit/block/BlockSnowLayer.java
+++ b/src/main/java/cn/nukkit/block/BlockSnowLayer.java
@@ -1,6 +1,7 @@
 package cn.nukkit.block;
 
 import cn.nukkit.Player;
+import cn.nukkit.event.block.BlockFadeEvent;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemSnowball;
 import cn.nukkit.item.ItemTool;
@@ -81,7 +82,11 @@ public class BlockSnowLayer extends BlockFallable {
         super.onUpdate(type);
         if (type == Level.BLOCK_UPDATE_RANDOM) {
             if (this.getLevel().getBlockLightAt((int) this.x, (int) this.y, (int) this.z) >= 10) {
-                this.getLevel().setBlock(this, new BlockAir(), true);
+                BlockFadeEvent event = new BlockFadeEvent(this, get(AIR));
+                level.getServer().getPluginManager().callEvent(event);
+                if (!event.isCancelled()) {
+                    level.setBlock(this, event.getNewBlock(), true);
+                }
                 return Level.BLOCK_UPDATE_NORMAL;
             }
         }

--- a/src/main/java/cn/nukkit/block/BlockSnowLayer.java
+++ b/src/main/java/cn/nukkit/block/BlockSnowLayer.java
@@ -85,7 +85,7 @@ public class BlockSnowLayer extends BlockFallable {
                 BlockFadeEvent event = new BlockFadeEvent(this, get(AIR));
                 level.getServer().getPluginManager().callEvent(event);
                 if (!event.isCancelled()) {
-                    level.setBlock(this, event.getNewBlock(), true);
+                    level.setBlock(this, event.getNewState(), true);
                 }
                 return Level.BLOCK_UPDATE_NORMAL;
             }

--- a/src/main/java/cn/nukkit/event/block/BlockFadeEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockFadeEvent.java
@@ -1,0 +1,25 @@
+package cn.nukkit.event.block;
+
+import cn.nukkit.block.Block;
+import cn.nukkit.event.Cancellable;
+import cn.nukkit.event.HandlerList;
+
+public class BlockFadeEvent extends BlockEvent implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    public static HandlerList getHandlers() {
+        return handlers;
+    }
+
+    private final Block newBlock;
+
+    public BlockFadeEvent(Block block, Block newBlock) {
+        super(block);
+        this.newBlock = newBlock;
+    }
+
+    public Block getNewBlock() {
+        return newBlock;
+    }
+}

--- a/src/main/java/cn/nukkit/event/block/BlockFadeEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockFadeEvent.java
@@ -12,14 +12,14 @@ public class BlockFadeEvent extends BlockEvent implements Cancellable {
         return handlers;
     }
 
-    private final Block newBlock;
+    private final Block newState;
 
-    public BlockFadeEvent(Block block, Block newBlock) {
+    public BlockFadeEvent(Block block, Block newState) {
         super(block);
-        this.newBlock = newBlock;
+        this.newState = newState;
     }
 
-    public Block getNewBlock() {
-        return newBlock;
+    public Block getNewState() {
+        return newState;
     }
 }


### PR DESCRIPTION
Called when a block fades, melts or disappears based on world conditions

Examples:
- Snow melting due to being near a light source.
- Ice melting due to being near a light source.
- Fire burning out after time, without destroying fuel block.

If a Block Fade event is cancelled, the block will not fade, melt or disappear.