### PR TITLE
Switching the order of player kicking and plugin disabling on shutdown

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -817,12 +817,12 @@ public class Server {
                 this.rcon.close();
             }
 
-            this.getLogger().debug("Disabling all plugins");
-            this.pluginManager.disablePlugins();
-
             for (Player player : new ArrayList<>(this.players.values())) {
                 player.close(player.getLeaveMessage(), this.getConfig("settings.shutdown-message", "Server closed"));
             }
+
+            this.getLogger().debug("Disabling all plugins");
+            this.pluginManager.disablePlugins();
 
             this.getLogger().debug("Removing event handlers");
             HandlerList.unregisterAll();


### PR DESCRIPTION
Kick the players before unregistering the plugins, so that the PlayerQuitEvent (and maybe other custom events) get called before the plugin is disabled, allowing for correct playerdata saving on a server shutdown