### PR TITLE
Check near entities even player doesn't move

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -1540,9 +1540,6 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                 }
             }
 
-            if (!this.isSpectator()) {
-                this.checkNearEntities();
-            }
             if (this.speed == null) speed = new Vector3(from.x - to.x, from.y - to.y, from.z - to.z);
             else this.speed.setComponents(from.x - to.x, from.y - to.y, from.z - to.z);
         } else {
@@ -1665,6 +1662,10 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
         if (this.spawned) {
             this.processMovement(tickDiff);
+
+            if (!this.isSpectator()) {
+                this.checkNearEntities();
+            }
 
             this.entityBaseTick(tickDiff);
 


### PR DESCRIPTION
This fixes the bug where player can stand on dropped items or xp orbs but doesn't pick them up unless he is moving. This also make picking up big xp amounts much more nicer when you don't have to move for long time before you have picked up them all.