### PR TITLE
fix signed varints

### DIFF
--- a/src/main/java/cn/nukkit/utils/VarInt.java
+++ b/src/main/java/cn/nukkit/utils/VarInt.java
@@ -30,7 +30,7 @@ public final class VarInt {
      */
     public static long encodeZigZag32(int v) {
         // Note:  the right-shift must be arithmetic
-        return (long) ((v << 1) ^ (v >> 31));
+        return ((v << 1) ^ (v >> 31)) & 0xFFFFFFFFL;
     }
 
     /**


### PR DESCRIPTION
fixed the direct cast after the bit futzing and changed to a masked cast. 0x7FFFFFFF as a signed int was producing a 10-byte varint otherwise