### PR TITLE
Fix enchantment bugs

### DIFF
--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -567,7 +567,7 @@ public class Item implements Cloneable, BlockID, ItemID {
             if (entry.getShort("id") == id) {
                 Enchantment e = Enchantment.getEnchantment(entry.getShort("id"));
                 if (e != null) {
-                    e.setLevel(entry.getShort("lvl"));
+                    e.setLevel(entry.getShort("lvl"), false);
                     return e;
                 }
             }

--- a/src/main/java/cn/nukkit/item/enchantment/Enchantment.java
+++ b/src/main/java/cn/nukkit/item/enchantment/Enchantment.java
@@ -166,7 +166,7 @@ public abstract class Enchantment implements Cloneable {
         if (level > this.getMaxLevel()) {
             this.level = this.getMaxLevel();
         } else if (level < this.getMinLevel()) {
-            this.level = this.getMaxLevel();
+            this.level = this.getMinLevel();
         } else {
             this.level = level;
         }


### PR DESCRIPTION
Bug：when use Item:getEnchantment, the Enchantment whose level is higher than its MaxLevel will be set to the MaxLevel
It makes trouble when developers want to customize item's enchantments