### PR TITLE
Sentry.IO integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,13 @@
             <version>${jline.version}</version>
             <scope>compile</scope>
         </dependency>
+        
+        <!-- https://mvnrepository.com/artifact/io.sentry/sentry -->
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry</artifactId>
+            <version>1.7.27</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,7 @@
             <groupId>io.sentry</groupId>
             <artifactId>sentry</artifactId>
             <version>1.7.27</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -364,6 +364,10 @@ public class Server {
             String dsn = this.config.get("sentry.dsn", null);
             if (dsn != null && dsn.length() > 0) {
                 Sentry.init(dsn);
+            } else {
+                if (dsn == null && System.getProperty("sentry.dsn") != null) {
+                    Sentry.init(System.getProperty("sentry.dsn"));
+                }
             }
         }
 

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -79,6 +79,8 @@ import co.aikar.timings.Timings;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import io.sentry.Sentry;
+import io.sentry.SentryClient;
+import io.sentry.SentryClientFactory;
 import lombok.extern.log4j.Log4j2;
 import org.iq80.leveldb.CompressionType;
 import org.iq80.leveldb.DB;
@@ -243,6 +245,8 @@ public class Server {
 
     private PlayerDataSerializer playerDataSerializer = new DefaultPlayerDataSerializer(this);
 
+    private SentryClient sentryClient = null;
+
     Server(final String filePath, String dataPath, String pluginPath, String predefinedLanguage) {
         Preconditions.checkState(instance == null, "Already initialized!");
         currentThread = Thread.currentThread(); // Saves the current thread instance as a reference, used in Server#isPrimaryThread()
@@ -363,10 +367,10 @@ public class Server {
         if (this.config.get("sentry.enable", false)) {
             String dsn = this.config.get("sentry.dsn", null);
             if (dsn != null && dsn.length() > 0) {
-                Sentry.init(dsn);
+                this.sentryClient = SentryClientFactory.sentryClient(dsn);
             } else {
                 if (dsn == null && System.getProperty("sentry.dsn") != null) {
-                    Sentry.init(System.getProperty("sentry.dsn"));
+                    this.sentryClient = SentryClientFactory.sentryClient(System.getProperty("sentry.dsn"));
                 }
             }
         }
@@ -2366,5 +2370,9 @@ public class Server {
         public void run() {
             console.start();
         }
+    }
+
+    public SentryClient getSentryClient() {
+        return sentryClient;
     }
 }

--- a/src/main/java/cn/nukkit/utils/bugreport/BugReportGenerator.java
+++ b/src/main/java/cn/nukkit/utils/bugreport/BugReportGenerator.java
@@ -118,6 +118,8 @@ public class BugReportGenerator extends Thread {
         OperatingSystemMXBean osMXBean = (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
 
         Sentry.getContext().clear();
+
+        // Extra
         Sentry.getContext().addExtra("NUKKIT_VERSION", Nukkit.VERSION);
         Sentry.getContext().addExtra("JAVA_VERSION", System.getProperty("java.vm.name") + " (" + System.getProperty("java.runtime.version") + ")");
         Sentry.getContext().addExtra("HOSTOS", osMXBean.getName() + "-" + osMXBean.getArch() + " [" + osMXBean.getVersion() + "]");
@@ -125,6 +127,10 @@ public class BugReportGenerator extends Thread {
         Sentry.getContext().addExtra("CPU_TYPE", cpuType == null ? "UNKNOWN" : cpuType);
         Sentry.getContext().addExtra("AVAILABLE_CORE", String.valueOf(osMXBean.getAvailableProcessors()));
         Sentry.getContext().addExtra("PLUGIN_ERROR", Boolean.toString(pluginError).toUpperCase());
+
+        // Tags
+        Sentry.getContext().addTag("plugin_error", String.valueOf(pluginError));
+        Sentry.getContext().addTag("nukkit_version", Nukkit.VERSION);
 
         Sentry.capture(throwable);
     }

--- a/src/main/java/cn/nukkit/utils/bugreport/BugReportGenerator.java
+++ b/src/main/java/cn/nukkit/utils/bugreport/BugReportGenerator.java
@@ -39,7 +39,6 @@ public class BugReportGenerator extends Thread {
 
             // Sentry
             if (Sentry.getStoredClient() != null) {
-                Server.getInstance().getLogger().info("[BugReport] Sentry ...");
                 captureSentry();
             }
 


### PR DESCRIPTION
This pull request adds a Sentry.IO integration.
When Nukkit creates a bug report, the exception is also sent to a sentry instance.

**What is Sentry?**
```
Open-source error tracking that helps developers monitor and fix crashes in real time.
Iterate continuously. Boost workflow efficiency. Improve user experience.
```

**Activate Sentry Integration**
To enable this integration you have to add the section "sentry" to the `nukkit.yml`:
```yaml
sentry:
  enable: true
  dsn: 'https://public:private@host:port/1'
```
The following information is appended to the sentry event:
* NUKKIT_VERSION (also as a tag)
* JAVA_VERSION
* HOSTOS
* MEMORY
* CPU_TYPE
* AVAILABLE_CORE
* PLUGIN_ERROR (also as tag)

**A Sentry event looks like this:**
![img](https://i.imgur.com/APQY1rS.png)