### PR TITLE
Bump API version

### DIFF
--- a/src/main/java/cn/nukkit/Nukkit.java
+++ b/src/main/java/cn/nukkit/Nukkit.java
@@ -39,7 +39,7 @@ public class Nukkit {
 
     public final static Properties GIT_INFO = getGitInfo();
     public final static String VERSION = getVersion();
-    public final static String API_VERSION = "1.0.8";
+    public final static String API_VERSION = "1.0.9";
     public final static String CODENAME = "";
     @Deprecated
     public final static String MINECRAFT_VERSION = ProtocolInfo.MINECRAFT_VERSION;


### PR DESCRIPTION
There is new stuff and events added to Nukkit since API 1.0.8 so bumping the API version could be good idea so plugin developers can target their plugins to the new API if needed