### PR TITLE
Fix some coloured messages

### DIFF
--- a/src/main/java/cn/nukkit/Achievement.java
+++ b/src/main/java/cn/nukkit/Achievement.java
@@ -29,7 +29,7 @@ public class Achievement {
         if (!achievements.containsKey(achievementId)) {
             return false;
         }
-        String translation = Server.getInstance().getLanguage().translateString("chat.type.achievement", player.getDisplayName(), TextFormat.GREEN + achievements.get(achievementId).getMessage());
+        String translation = Server.getInstance().getLanguage().translateString("chat.type.achievement", player.getDisplayName(), TextFormat.GREEN + achievements.get(achievementId).getMessage() + TextFormat.RESET);
 
         if (Server.getInstance().getPropertyBoolean("announce-player-achievements", true)) {
             Server.getInstance().broadcastMessage(translation);

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -364,7 +364,7 @@ public class Server {
         this.forceLanguage = this.getConfig("settings.force-language", false);
         this.baseLang = new BaseLang(this.getConfig("settings.language", BaseLang.FALLBACK_LANGUAGE));
         log.info(this.getLanguage().translateString("language.selected", new String[]{getLanguage().getName(), getLanguage().getLang()}));
-        log.info(getLanguage().translateString("nukkit.server.start", TextFormat.AQUA + this.getVersion() + TextFormat.WHITE));
+        log.info(getLanguage().translateString("nukkit.server.start", TextFormat.AQUA + this.getVersion() + TextFormat.RESET));
 
         Object poolSize = this.getConfig("settings.async-workers", (Object) "auto");
         if (!(poolSize instanceof Integer)) {


### PR DESCRIPTION
Some coloured messages (`chat.type.achievement` and `nukkit.server.start`) had a problem with some languages because of differences in word order, which was not easy to notice in English as they look like nothing is wrong with them. This PR addresses the issue by `TextFormat.RESET`ing at the end of the message.