### PR TITLE
Missing time abbreviations

### DIFF
--- a/src/main/java/cn/nukkit/permission/BanEntry.java
+++ b/src/main/java/cn/nukkit/permission/BanEntry.java
@@ -16,7 +16,7 @@ import java.util.TreeMap;
  * Nukkit Project
  */
 public class BanEntry {
-    public static final String format = "yyyy-MM-dd hh:mm:ss Z";
+    public static final String format = "yyyy-MM-dd hh:mm:ss a Z";
 
     private final String name;
     private Date creationDate = null;


### PR DESCRIPTION
Date Time format was missing AM and PM abbreviations.

It was causing that after server restart dates were loaded as 4 o'clock in the morning not in the afternoon.