### PR TITLE
Update block pickup to behave vanilla-like

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2657,7 +2657,17 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     this.server.getPluginManager().callEvent(pickEvent);
 
                     if (!pickEvent.isCancelled()) {
-                        this.inventory.setItemInHand(pickEvent.getItem());
+                        boolean itemExists = false;
+                        for (int slot = 0; slot != this.inventory.getHotbarSize(); slot++) {
+                            if (this.inventory.getItem(slot).equals(pickEvent.getItem())) {
+                                this.inventory.setHeldItemSlot(slot);
+                                itemExists = true;
+                                break;
+                            }
+                        }
+                        if (!itemExists) {
+                            this.inventory.setItemInHand(pickEvent.getItem());
+                        }
                     }
                     break;
                 case ProtocolInfo.ANIMATE_PACKET:


### PR DESCRIPTION
- Remove item duplication on item pickup (Only if item exists in hotbar)
- Set hotbar slot to the item if it already exists instead of picking it up