### PR TITLE
Add missing getters/setters for BlockEntityFurnace

### DIFF
--- a/src/main/java/cn/nukkit/blockentity/BlockEntityFurnace.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityFurnace.java
@@ -315,4 +315,35 @@ public class BlockEntityFurnace extends BlockEntitySpawnable implements Inventor
         return c;
     }
 
+    public int getBurnTime() {
+        return burnTime;
+    }
+
+    public void setBurnTime(int burnTime) {
+        this.burnTime = burnTime;
+    }
+
+    public int getBurnDuration() {
+        return burnDuration;
+    }
+
+    public void setBurnDuration(int burnDuration) {
+        this.burnDuration = burnDuration;
+    }
+
+    public int getCookTime() {
+        return cookTime;
+    }
+
+    public void setCookTime(int cookTime) {
+        this.cookTime = cookTime;
+    }
+
+    public int getMaxTime() {
+        return maxTime;
+    }
+
+    public void setMaxTime(int maxTime) {
+        this.maxTime = maxTime;
+    }
 }


### PR DESCRIPTION
This PR adds missing getters and setters for the burn time, burn duration, cook time and max time in BlockEntityFurnace.