### PR TITLE
Just a block getName change

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockCoal.java
+++ b/src/main/java/cn/nukkit/block/BlockCoal.java
@@ -43,7 +43,7 @@ public class BlockCoal extends BlockSolid {
 
     @Override
     public String getName() {
-        return "Block of Coal";
+        return "Coal Block";
     }
 
     @Override


### PR DESCRIPTION
As I was going through the blocks I noticed that coal had an irregular name compared to the others. 
This changes it from 'Block of Coal' to 'Coal Block' which is consistent with all other ores