### PR TITLE
Generate a skin ID if one does not exist.

### DIFF
--- a/src/main/java/cn/nukkit/entity/data/Skin.java
+++ b/src/main/java/cn/nukkit/entity/data/Skin.java
@@ -1,6 +1,7 @@
 package cn.nukkit.entity.data;
 
 import cn.nukkit.nbt.stream.FastByteArrayOutputStream;
+import cn.nukkit.utils.Binary;
 import cn.nukkit.utils.SerializedImage;
 import cn.nukkit.utils.SkinAnimation;
 import com.google.common.base.Preconditions;
@@ -10,9 +11,11 @@ import net.minidev.json.JSONValue;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 /**
  * author: MagicDroidX
@@ -73,6 +76,9 @@ public class Skin {
     }
 
     public String getSkinId() {
+        if (this.skinId == null) {
+            this.generateSkinId("Custom");
+        }
         return skinId;
     }
 
@@ -81,6 +87,11 @@ public class Skin {
             return;
         }
         this.skinId = skinId;
+    }
+
+    public void generateSkinId(String name) {
+        byte[] data = Binary.appendBytes(getSkinData().data, getSkinResourcePatch().getBytes(StandardCharsets.UTF_8));
+        this.skinId = UUID.nameUUIDFromBytes(data) + "." + name;
     }
 
     public void setSkinData(byte[] skinData) {
@@ -212,7 +223,7 @@ public class Skin {
     }
 
     public String getFullSkinId() {
-        return skinId; //TODO: Client sends full skin ID as normal skin ID. Find out what this is actually for.
+        return getSkinId() + getCapeId();
     }
 
     private static SerializedImage parseBufferedImage(BufferedImage image) {

--- a/src/main/java/cn/nukkit/level/particle/FloatingTextParticle.java
+++ b/src/main/java/cn/nukkit/level/particle/FloatingTextParticle.java
@@ -8,11 +8,9 @@ import cn.nukkit.level.Level;
 import cn.nukkit.level.Location;
 import cn.nukkit.math.Vector3;
 import cn.nukkit.network.protocol.*;
-import cn.nukkit.utils.Binary;
 import cn.nukkit.utils.SerializedImage;
 import com.google.common.base.Strings;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
@@ -24,14 +22,10 @@ import java.util.concurrent.ThreadLocalRandom;
 public class FloatingTextParticle extends Particle {
     private static final Skin EMPTY_SKIN = new Skin();
     private static final SerializedImage SKIN_DATA = SerializedImage.fromLegacy(new byte[8192]);
-    private static final UUID SKIN_UUID = UUID.nameUUIDFromBytes(Binary.appendBytes(Skin.GEOMETRY_CUSTOM.getBytes(StandardCharsets.UTF_8), SKIN_DATA.data));
 
     static {
         EMPTY_SKIN.setSkinData(SKIN_DATA);
-        EMPTY_SKIN.setSkinResourcePatch(Skin.GEOMETRY_CUSTOM);
-        EMPTY_SKIN.setSkinId(SKIN_UUID + ".FloatingText");
-        EMPTY_SKIN.setCapeData(SerializedImage.EMPTY);
-        EMPTY_SKIN.setCapeId("");
+        EMPTY_SKIN.generateSkinId("FloatingText");
     }
 
     protected UUID uuid = UUID.randomUUID();


### PR DESCRIPTION
If a unique skin ID is not set, the client will display incorrect skins for everyone on the server.