### PR TITLE
Enhancing Chunk Loading Performance

### DIFF
--- a/src/main/java/cn/nukkit/level/format/anvil/util/BlockStorage.java
+++ b/src/main/java/cn/nukkit/level/format/anvil/util/BlockStorage.java
@@ -22,7 +22,7 @@ public class BlockStorage {
     private static int getIndex(int x, int y, int z) {
         int index = (x << 8) + (z << 4) + y; // XZY = Bedrock format
         //Preconditions.checkArgument(index >= 0 && index < SECTION_SIZE, "Invalid index");
-        if(index < 0 || index >= SECTION_SIZE) throw new IllegalArgumentException();
+        if(index < 0 || index >= SECTION_SIZE) throw new IllegalArgumentException("Invalid index");
         return index;
     }
 

--- a/src/main/java/cn/nukkit/level/format/anvil/util/BlockStorage.java
+++ b/src/main/java/cn/nukkit/level/format/anvil/util/BlockStorage.java
@@ -21,7 +21,8 @@ public class BlockStorage {
 
     private static int getIndex(int x, int y, int z) {
         int index = (x << 8) + (z << 4) + y; // XZY = Bedrock format
-        Preconditions.checkArgument(index >= 0 && index < SECTION_SIZE, "Invalid index");
+        //Preconditions.checkArgument(index >= 0 && index < SECTION_SIZE, "Invalid index");
+        if(index < 0 || index >= SECTION_SIZE) throw new IllegalArgumentException();
         return index;
     }
 

--- a/src/main/java/cn/nukkit/level/format/anvil/util/NibbleArray.java
+++ b/src/main/java/cn/nukkit/level/format/anvil/util/NibbleArray.java
@@ -15,8 +15,9 @@ public class NibbleArray implements Cloneable {
     }
 
     public byte get(int index) {
-        Preconditions.checkElementIndex(index, data.length * 2);
-        byte val = data[index / 2];
+        //Preconditions.checkElementIndex(index, data.length * 2);
+    	if(index >= data.length << 1) throw new IndexOutOfBoundsException();
+        byte val = data[index >> 1]; //[index / 2];
         if ((index & 1) == 0) {
             return (byte) (val & 0x0f);
         } else {
@@ -25,10 +26,17 @@ public class NibbleArray implements Cloneable {
     }
 
     public void set(int index, byte value) {
-        Preconditions.checkArgument(value >= 0 && value < 16, "Nibbles must have a value between 0 and 15.");
-        Preconditions.checkElementIndex(index, data.length * 2);
+        //Preconditions.checkArgument(value >= 0 && value < 16, "Nibbles must have a value between 0 and 15.");
+        //Preconditions.checkElementIndex(index, data.length * 2);
+        if(value != (value & 15))
+        {
+        	throw new IllegalArgumentException("Nibbles must have a value between 0 and 15.");
+        }else if(index >= data.length << 1 || index < 0)        		
+        {
+        	throw new IndexOutOfBoundsException();
+        }
         value &= 0xf;
-        int half = index / 2;
+        int half = index >> 1; // index / 2;
         byte previous = data[half];
         if ((index & 1) == 0) {
             data[half] = (byte) (previous & 0xf0 | value);


### PR DESCRIPTION
https://i.imgur.com/ehqKINe.png
https://i.imgur.com/ffiiXC5.png

![Speedup chart](https://i.imgur.com/MuyTSA5.png)

After doing some profiling, it's easy to see that the Preconditions function calls in NibbleArray.set() and BlockStorage.getIndex() (Functions that are called millions of times when a level is loaded for a player) add a substantial amount of overhead. These functions simply check that a boolean expression is true, else it throws an exception. By replacing [these calls with equivalent code](https://github.com/google/guava/wiki/PreconditionsExplained), Chunk.fromBinary() can return chunks at nearly twice the rate.

I have also replaced some multiply and divide operations with bitshifts to further improve the performance of NibbleArray.set() and NibbleArray.get() given that they are called many millions of times.