### PR TITLE
Fixes piston heads not rendering

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockPistonBase.java
+++ b/src/main/java/cn/nukkit/block/BlockPistonBase.java
@@ -66,6 +66,7 @@ public abstract class BlockPistonBase extends BlockSolidMeta implements Faceable
                 .putBoolean("Sticky", this.sticky);
 
         BlockEntityPistonArm be = new BlockEntityPistonArm(this.level.getChunk((int) this.x >> 4, (int) this.z >> 4), nbt);
+        be.spawnToAll();
 
         //this.checkState();
         return true;

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityPistonArm.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityPistonArm.java
@@ -1,5 +1,6 @@
 package cn.nukkit.blockentity;
 
+import cn.nukkit.block.Block;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.level.format.FullChunk;
 import cn.nukkit.math.AxisAlignedBB;
@@ -13,18 +14,18 @@ import cn.nukkit.nbt.tag.ListTag;
 /**
  * @author CreeperFace
  */
-public class BlockEntityPistonArm extends BlockEntity {
+public class BlockEntityPistonArm extends BlockEntitySpawnable {
 
-    public float progress = 1.0F;
-    public float lastProgress = 1.0F;
+    public float progress;
+    public float lastProgress;
     public BlockFace facing;
-    public boolean extending = false;
-    public boolean sticky = false;
-    public byte state = 1;
-    public byte newState = 1;
-    public Vector3 attachedBlock = null;
-    public boolean isMovable = true;
-    public boolean powered = false;
+    public boolean extending;
+    public boolean sticky;
+    public byte state;
+    public byte newState;
+    public Vector3 attachedBlock;
+    public boolean isMovable;
+    public boolean powered;
 
     public BlockEntityPistonArm(FullChunk chunk, CompoundTag nbt) {
         super(chunk, nbt);
@@ -32,6 +33,8 @@ public class BlockEntityPistonArm extends BlockEntity {
 
     @Override
     protected void initBlockEntity() {
+        this.isMovable = true;
+        
         if (namedTag.contains("Progress")) {
             this.progress = namedTag.getFloat("Progress");
         }
@@ -82,7 +85,8 @@ public class BlockEntityPistonArm extends BlockEntity {
     }
 
     public boolean isBlockEntityValid() {
-        return true;
+        int blockId = getBlock().getId();
+        return blockId == Block.PISTON || blockId == Block.STICKY_PISTON;
     }
 
     public void saveNBT() {
@@ -96,6 +100,15 @@ public class BlockEntityPistonArm extends BlockEntity {
     }
 
     public CompoundTag getSpawnCompound() {
-        return (new CompoundTag()).putString("id", "PistonArm").putInt("x", (int) this.x).putInt("y", (int) this.y).putInt("z", (int) this.z);
+        return new CompoundTag()
+                .putString("id", BlockEntity.PISTON_ARM)
+                .putInt("x", (int) this.x)
+                .putInt("y", (int) this.y)
+                .putInt("z", (int) this.z)
+                .putFloat("Progress", this.progress)
+                .putFloat("LastProgress", this.lastProgress)
+                .putBoolean("Sticky", this.sticky)
+                .putByte("State", this.state)
+                .putByte("NewState", this.newState);
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3679022/71496415-ef35a400-2831-11ea-8a20-55baa50e1635.png)

The BlockEntity wasn't BlockEntitySpawnable so it wasn't spawning to the client, the field initializers were overriding the data loaded from NBT at initBlockEntity and the default data were set to the extended state. I also implemented the isBlockEntityValid method, so we won't have BlockEntityPistonArm in invalid blocks

How to reproduce the issue:
1. Place some pistons
2. Disconnect
3. Reconnect. They will be correctly oriented but without heads

Notes: 
* Old pistons might render as extended because they were being placed as extended by default, we just couldn't see it
* Old sticky pistons had the "sticky" entity property overridden to false even though the block in the same position is STICKY_PISTON, so they will be kinda inconsistent, maybe we should force it to actually check which block is there in the initBlockEntity method instead of taking the one stored in the NBT tags
* This will fixes the rendering when you reload the chunks, not the piston functionality