### PR TITLE
Fixes inventory issues with items with lists in the named tags.

### DIFF
--- a/src/main/java/cn/nukkit/nbt/tag/ListTag.java
+++ b/src/main/java/cn/nukkit/nbt/tag/ListTag.java
@@ -44,6 +44,7 @@ public class ListTag<T extends Tag> extends Tag {
         for (int i = 0; i < size; i++) {
             Tag tag = Tag.newTag(type, null);
             tag.load(dis);
+            tag.setName("");
             list.add((T) tag);
         }
     }
@@ -72,12 +73,14 @@ public class ListTag<T extends Tag> extends Tag {
 
     public ListTag<T> add(T tag) {
         type = tag.getId();
+        tag.setName("");
         list.add(tag);
         return this;
     }
 
     public ListTag<T> add(int index, T tag) {
         type = tag.getId();
+        tag.setName("");
 
         if (index >= list.size()) {
             list.add(index, tag);


### PR DESCRIPTION
The issue is the ListTag's entries should not have names.

https://minecraft.gamepedia.com/NBT_format#TAG_definition
> TAG_List: A list of tag payloads, without repeated tag IDs or any tag names.

So when the client receives an item which contains a list tag with named tags, the client remove them, so when the client attempts to interact with the item the server will reject the packets because the NBT tags mismatches.

To reproduce, I created this sample plugin which captures skeletons into bone items (the Entity.saveNBT() method adds ListTag with named values in "Pos", "Motion", and "Rotation", so I used that to fuel the example plugin)

The example plugin: https://gist.github.com/joserobjr/702a87fba0f9ffc8166f215065d51f2b

Steps to reproduce:
1. Install the example plugin
2. Start and login to the server
3. Go in creative mode
4. Grab some Skeleton Spawn Eggs
5. Grab some bone
6. Go in survival mode
7. Spawn a Skeleton
8. Right click the Skeleton with the bones in your hands. It will capture the skeleton in a dropped item
9. Grab the dropped item
10. Change the active slot to the spawned bone (this action will silently fail)
11. Try to right click a block with the bone (the action will fail and your active slot will be reverted)
12. Open your inventory
13. Try to grab the captured bone with your mouse  (the action will fail)

Clearing the name before adding it to the NbtList fixes the problem.

Note: If you reconnect your will be resync in a way that you will be able to use the item so you will need to capture an other skeleton to reproduce the issue again
