### PR TITLE
Fixes ghost flower on the side of the pot after adding a flower to a pot

### DIFF
--- a/src/main/java/cn/nukkit/blockentity/BlockEntityFlowerPot.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityFlowerPot.java
@@ -39,13 +39,18 @@ public class BlockEntityFlowerPot extends BlockEntitySpawnable {
 
     @Override
     public CompoundTag getSpawnCompound() {
-        return new CompoundTag()
+        CompoundTag tag = new CompoundTag()
                 .putString("id", BlockEntity.FLOWER_POT)
                 .putInt("x", (int) this.x)
                 .putInt("y", (int) this.y)
-                .putInt("z", (int) this.z)
-                .putShort("item", this.namedTag.getShort("item"))
-                .putInt("mData", this.namedTag.getInt("data"));
+                .putInt("z", (int) this.z);
+
+        int item = namedTag.getShort("item");
+        if (item != Block.AIR) {
+            tag.putShort("item", this.namedTag.getShort("item"))
+                    .putInt("mData", this.namedTag.getInt("data"));
+        }
+        return tag;
     }
 
 }


### PR DESCRIPTION
Steps to reproduce:
1. Place a flower pot
2. Add any flower to it right clicking the side of a block which have a solid block above

![image](https://user-images.githubusercontent.com/3679022/72312751-d87fb180-3667-11ea-9eba-793ed3fc73c5.png)

