### PR TITLE
Hide player data not found message if player data saving is disabled

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -1621,7 +1621,7 @@ public class Server {
         }
         CompoundTag nbt = null;
         if (create) {
-            if (this.shouldSavePlayerData() {
+            if (this.shouldSavePlayerData()) {
                 log.info(this.getLanguage().translateString("nukkit.data.playerNotFound", name));
             }
             Position spawn = this.getDefaultLevel().getSafeSpawn();

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -1621,7 +1621,9 @@ public class Server {
         }
         CompoundTag nbt = null;
         if (create) {
-            log.info(this.getLanguage().translateString("nukkit.data.playerNotFound", name));
+            if (this.shouldSavePlayerData() {
+                log.info(this.getLanguage().translateString("nukkit.data.playerNotFound", name));
+            }
             Position spawn = this.getDefaultLevel().getSafeSpawn();
             nbt = new CompoundTag()
                     .putLong("firstPlayed", System.currentTimeMillis() / 1000)


### PR DESCRIPTION
This was already fixed earlier but came back after some changes