### PR TITLE
Prevent access to chunks that haven't had themselves or their neighbors populated

### DIFF
--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -2215,6 +2215,27 @@ public class Level implements ChunkManager, Metadatable {
         return this.chunkManager.getChunkFuture(chunkX, chunkZ);
     }
 
+    /**
+     * @see LevelChunkManager#getLoadedChunkFutureUnsafe(int, int)
+     */
+    public CompletableFuture<Chunk> getLoadedChunkFutureUnsafe(int x, int z) {
+        return this.chunkManager.getLoadedChunkFutureUnsafe(x, z);
+    }
+
+    /**
+     * @see LevelChunkManager#getGeneratedChunkFutureUnsafe(int, int)
+     */
+    public CompletableFuture<Chunk> getGeneratedChunkFutureUnsafe(int x, int z) {
+        return this.chunkManager.getGeneratedChunkFutureUnsafe(x, z);
+    }
+
+    /**
+     * @see LevelChunkManager#getPopulatedChunkFutureUnsafe(int, int)
+     */
+    public CompletableFuture<Chunk> getPopulatedChunkFutureUnsafe(int x, int z) {
+        return this.chunkManager.getPopulatedChunkFutureUnsafe(x, z);
+    }
+
     public int getHighestBlockAt(int x, int z) {
         return this.getChunk(x >> 4, z >> 4).getHighestBlock(x & 0x0f, z & 0x0f);
     }

--- a/src/main/java/cn/nukkit/level/chunk/Chunk.java
+++ b/src/main/java/cn/nukkit/level/chunk/Chunk.java
@@ -446,22 +446,37 @@ public final class Chunk implements IChunk, Closeable {
 
     @Override
     public boolean isGenerated() {
-        return unsafe.isGenerated();
+        return this.unsafe.isGenerated();
     }
 
     @Override
-    public void setGenerated(boolean generated) {
-        unsafe.setGenerated(generated);
+    public void setGenerated() {
+        this.unsafe.setGenerated();
     }
 
     @Override
     public boolean isPopulated() {
-        return unsafe.isPopulated();
+        return this.unsafe.isPopulated();
     }
 
     @Override
-    public void setPopulated(boolean populated) {
-        unsafe.setPopulated(populated);
+    public void setPopulated() {
+        this.unsafe.setPopulated();
+    }
+
+    @Override
+    public boolean isPopulatedAround() {
+        return this.unsafe.isPopulatedAround();
+    }
+
+    @Override
+    public void onChunkPopulated(int chunkX, int chunkZ) {
+        this.unsafe.onChunkPopulated(chunkX, chunkZ);
+    }
+
+    @Override
+    public boolean isFromDisk() {
+        return this.unsafe.isFromDisk();
     }
 
     @Override

--- a/src/main/java/cn/nukkit/level/chunk/ChunkBuilder.java
+++ b/src/main/java/cn/nukkit/level/chunk/ChunkBuilder.java
@@ -91,8 +91,12 @@ public class ChunkBuilder {
         Preconditions.checkNotNull(this.heightMap, "heightMap");
         Chunk chunk = new Chunk(new UnsafeChunk(this.x, this.z, this.level, this.sections, this.biomes,
                 this.heightMap), this.chunkDataLoaders, this.blockUpdates);
-        chunk.setGenerated(this.generated);
-        chunk.setPopulated(this.populated);
+        if (this.generated) {
+            chunk.setGenerated();
+        }
+        if (this.populated) {
+            chunk.setPopulated();
+        }
         chunk.setDirty(this.dirty);
         return chunk;
     }

--- a/src/main/java/cn/nukkit/level/chunk/IChunk.java
+++ b/src/main/java/cn/nukkit/level/chunk/IChunk.java
@@ -220,19 +220,20 @@ public interface IChunk {
 
     boolean isGenerated();
 
-    void setGenerated(boolean generated);
-
-    default void setGenerated() {
-        this.setGenerated(true);
-    }
+    void setGenerated();
 
     boolean isPopulated();
 
-    void setPopulated(boolean populated);
+    void setPopulated();
 
-    default void setPopulated() {
-        this.setPopulated(true);
-    }
+    boolean isPopulatedAround();
+
+    void onChunkPopulated(int chunkX, int chunkZ);
+
+    /**
+     * @return whether or not the chunk was loaded from disk
+     */
+    boolean isFromDisk();
 
     /**
      * Whether the chunk has changed since it was last loaded or saved.

--- a/src/main/java/cn/nukkit/level/chunk/LockableChunk.java
+++ b/src/main/java/cn/nukkit/level/chunk/LockableChunk.java
@@ -18,7 +18,7 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 
 @NotThreadSafe
-public final class LockableChunk implements IChunk, Lock {
+public final class LockableChunk implements IChunk, Lock, Comparable<LockableChunk> {
     private final UnsafeChunk unsafe;
     private final Lock lock;
 
@@ -284,5 +284,11 @@ public final class LockableChunk implements IChunk, Lock {
     @Override
     public void clear() {
         this.unsafe.clear();
+    }
+
+    @Override
+    public int compareTo(LockableChunk o) {
+        int i = Integer.compare(this.getX(), o.getX());
+        return i == 0 ? Integer.compare(this.getZ(), o.getZ()) : i;
     }
 }

--- a/src/main/java/cn/nukkit/level/chunk/LockableChunk.java
+++ b/src/main/java/cn/nukkit/level/chunk/LockableChunk.java
@@ -238,22 +238,37 @@ public final class LockableChunk implements IChunk, Lock {
 
     @Override
     public boolean isGenerated() {
-        return unsafe.isGenerated();
+        return this.unsafe.isGenerated();
     }
 
     @Override
-    public void setGenerated(boolean generated) {
-        unsafe.setGenerated(generated);
+    public void setGenerated() {
+        this.unsafe.setGenerated();
     }
 
     @Override
     public boolean isPopulated() {
-        return unsafe.isPopulated();
+        return this.unsafe.isPopulated();
     }
 
     @Override
-    public void setPopulated(boolean populated) {
-        unsafe.setPopulated(populated);
+    public void setPopulated() {
+        this.unsafe.setPopulated();
+    }
+
+    @Override
+    public boolean isPopulatedAround() {
+        return this.unsafe.isPopulatedAround();
+    }
+
+    @Override
+    public void onChunkPopulated(int chunkX, int chunkZ) {
+        this.unsafe.onChunkPopulated(chunkX, chunkZ);
+    }
+
+    @Override
+    public boolean isFromDisk() {
+        return this.unsafe.isFromDisk();
     }
 
     @Override

--- a/src/main/java/cn/nukkit/level/chunk/UnsafeChunk.java
+++ b/src/main/java/cn/nukkit/level/chunk/UnsafeChunk.java
@@ -9,19 +9,27 @@ import cn.nukkit.registry.BlockRegistry;
 import cn.nukkit.utils.Identifier;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import it.unimi.dsi.fastutil.longs.LongArraySet;
+import it.unimi.dsi.fastutil.longs.LongSet;
+import it.unimi.dsi.fastutil.longs.LongSets;
 import it.unimi.dsi.fastutil.shorts.Short2ObjectMap;
 import it.unimi.dsi.fastutil.shorts.Short2ObjectOpenHashMap;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Closeable;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
 
-import static cn.nukkit.block.BlockIds.AIR;
-import static cn.nukkit.level.chunk.Chunk.ARRAY_SIZE;
-import static cn.nukkit.level.chunk.Chunk.SECTION_COUNT;
-import static com.google.common.base.Preconditions.checkElementIndex;
+import static cn.nukkit.block.BlockIds.*;
+import static cn.nukkit.level.chunk.Chunk.*;
+import static com.google.common.base.Preconditions.*;
 
 public final class UnsafeChunk implements IChunk, Closeable {
 
@@ -33,6 +41,8 @@ public final class UnsafeChunk implements IChunk, Closeable {
             .newUpdater(UnsafeChunk.class, "generated");
     private static final AtomicIntegerFieldUpdater<UnsafeChunk> POPULATED_FIELD = AtomicIntegerFieldUpdater
             .newUpdater(UnsafeChunk.class, "populated");
+    private static final AtomicIntegerFieldUpdater<UnsafeChunk> POPULATED_AROUND_FIELD = AtomicIntegerFieldUpdater
+            .newUpdater(UnsafeChunk.class, "populatedAround");
     private static final AtomicIntegerFieldUpdater<UnsafeChunk> CLOSED_FIELD = AtomicIntegerFieldUpdater
             .newUpdater(UnsafeChunk.class, "closed");
     static final AtomicIntegerFieldUpdater<UnsafeChunk> CLEAR_CACHE_FIELD = AtomicIntegerFieldUpdater
@@ -52,6 +62,8 @@ public final class UnsafeChunk implements IChunk, Closeable {
 
     private final Short2ObjectMap<BlockEntity> tiles = new Short2ObjectOpenHashMap<>();
 
+    private final LongSet waitingPopulationChunks;
+
     private final byte[] biomes;
 
     private final int[] heightMap;
@@ -64,9 +76,13 @@ public final class UnsafeChunk implements IChunk, Closeable {
 
     private volatile int populated;
 
+    private volatile int populatedAround;
+
     private volatile int closed;
 
     private volatile int clearCache;
+
+    private final boolean fromDisk;
 
     public UnsafeChunk(int x, int z, Level level) {
         this.x = x;
@@ -75,6 +91,23 @@ public final class UnsafeChunk implements IChunk, Closeable {
         this.sections = new ChunkSection[SECTION_COUNT];
         this.biomes = new byte[ARRAY_SIZE];
         this.heightMap = new int[ARRAY_SIZE];
+
+        this.fromDisk = false;
+        //porktodo: replace this with Generator#getPopulationChunks on dev/generator-api-rewrite
+        LongSet waitingPopulationChunks = new LongArraySet(8);
+        for (int deltaX = -1; deltaX <= 1; deltaX++)    {
+            for (int deltaZ = -1; deltaZ <= 1; deltaZ++)    {
+                if (deltaX != 0 || deltaZ != 0) {
+                    Chunk chunk = level.getLoadedChunk(x + deltaX, z + deltaZ);
+                    if (chunk != null && chunk.isPopulated()) { //don't add to the waiting list if the chunk is already populated
+                        continue;
+                    }
+                }
+                waitingPopulationChunks.add(Chunk.key(x + deltaX, z + deltaZ));
+            }
+        }
+
+        this.waitingPopulationChunks = LongSets.synchronize(waitingPopulationChunks);
     }
 
     UnsafeChunk(int x, int z, Level level, ChunkSection[] sections, byte[] biomes, int[] heightMap) {
@@ -87,6 +120,9 @@ public final class UnsafeChunk implements IChunk, Closeable {
         this.biomes = Arrays.copyOf(biomes, ARRAY_SIZE);
         Preconditions.checkNotNull(heightMap, "heightMap");
         this.heightMap = Arrays.copyOf(heightMap, ARRAY_SIZE);
+
+        this.fromDisk = true;
+        this.waitingPopulationChunks = LongSets.EMPTY_SET; //chunks cannot be stored to disk unless they were already populatedAround
     }
 
     static void checkBounds(int x, int y, int z) {
@@ -412,32 +448,60 @@ public final class UnsafeChunk implements IChunk, Closeable {
         return this.tiles.values();
     }
 
+    @Override
     public boolean isGenerated() {
-        return generated == 1;
+        return this.generated == 1;
     }
 
-    public void setGenerated(boolean generated) {
-        if (GENERATED_FIELD.compareAndSet(this, generated ? 0 : 1, generated ? 1 : 0)) {
-            setDirty();
-        }
-    }
-
+    @Override
     public void setGenerated() {
-        this.setGenerated(true);
+        GENERATED_FIELD.compareAndSet(this, 0, 1);
     }
 
+    @Override
     public boolean isPopulated() {
-        return populated == 1;
+        return this.populated == 1;
     }
 
-    public void setPopulated(boolean populated) {
-        if (POPULATED_FIELD.compareAndSet(this, populated ? 0 : 1, populated ? 1 : 0)) {
-            setDirty();
+    @Override
+    public void setPopulated() {
+        if (POPULATED_FIELD.compareAndSet(this, 0, 1))  {
+            this.onChunkPopulated(this.x, this.z);
+
+            //notify neighboring chunks that this chunk was populated
+            for (int deltaX = -1; deltaX <= 1; deltaX++)    {
+                for (int deltaZ = -1; deltaZ <= 1; deltaZ++)    {
+                    if (deltaX == 0 && deltaZ == 0) {
+                        continue;
+                    }
+
+                    Chunk chunk = this.level.getLoadedChunkFutureUnsafe(this.x + deltaX, this.z + deltaZ).getNow(null);
+                    if (chunk != null) {
+                        chunk.onChunkPopulated(this.x, this.z);
+                    }
+                }
+            }
         }
     }
 
-    public void setPopulated() {
-        this.setPopulated(true);
+    @Override
+    public boolean isPopulatedAround() {
+        return this.populatedAround == 1;
+    }
+
+    @Override
+    public void onChunkPopulated(int chunkX, int chunkZ) {
+        if (this.waitingPopulationChunks.remove(Chunk.key(chunkX, chunkZ))
+                && this.waitingPopulationChunks.isEmpty()
+                && POPULATED_AROUND_FIELD.compareAndSet(this, 0, 1)) {
+            System.out.printf("Chunk %d,%d is fully populatedAround!\n", this.x, this.z);
+            System.out.flush();
+        }
+    }
+
+    @Override
+    public boolean isFromDisk() {
+        return false;
     }
 
     /**
@@ -446,7 +510,7 @@ public final class UnsafeChunk implements IChunk, Closeable {
      * @return dirty
      */
     public boolean isDirty() {
-        return dirty == 1;
+        return this.populatedAround == 1 && this.dirty == 1;
     }
 
     /**

--- a/src/main/java/cn/nukkit/level/chunk/UnsafeChunk.java
+++ b/src/main/java/cn/nukkit/level/chunk/UnsafeChunk.java
@@ -491,11 +491,8 @@ public final class UnsafeChunk implements IChunk, Closeable {
 
     @Override
     public void onChunkPopulated(int chunkX, int chunkZ) {
-        if (this.waitingPopulationChunks.remove(Chunk.key(chunkX, chunkZ))
-                && this.waitingPopulationChunks.isEmpty()
-                && POPULATED_AROUND_FIELD.compareAndSet(this, 0, 1)) {
-            System.out.printf("Chunk %d,%d is fully populatedAround!\n", this.x, this.z);
-            System.out.flush();
+        if (this.waitingPopulationChunks.remove(Chunk.key(chunkX, chunkZ)) && this.waitingPopulationChunks.isEmpty()) {
+            POPULATED_AROUND_FIELD.compareAndSet(this, 0, 1);
         }
     }
 

--- a/src/main/java/cn/nukkit/level/generator/function/ChunkPopulateFunction.java
+++ b/src/main/java/cn/nukkit/level/generator/function/ChunkPopulateFunction.java
@@ -55,7 +55,7 @@ public class ChunkPopulateFunction implements BiFunction<Chunk, List<Chunk>, Chu
 
         manager.setSeed(this.level.getSeed());
         lockableChunks.forEach(manager::setChunk);
-        lockableChunks.forEach(Lock::lock);
+        //lockableChunks.forEach(Lock::lock);
         try {
             generator.populateChunk(manager, random, chunk.getX(), chunk.getZ());
 
@@ -68,7 +68,7 @@ public class ChunkPopulateFunction implements BiFunction<Chunk, List<Chunk>, Chu
         } finally {
             manager.clean();
             for (LockableChunk lockableChunk : lockableChunks) {
-                lockableChunk.unlock();
+                //lockableChunk.unlock();
                 lockableChunk.setDirty(false);
             }
         }

--- a/src/main/java/cn/nukkit/level/generator/function/ChunkPopulateFunction.java
+++ b/src/main/java/cn/nukkit/level/generator/function/ChunkPopulateFunction.java
@@ -2,6 +2,7 @@ package cn.nukkit.level.generator.function;
 
 import cn.nukkit.level.Level;
 import cn.nukkit.level.chunk.Chunk;
+import cn.nukkit.level.chunk.IChunk;
 import cn.nukkit.level.chunk.LockableChunk;
 import cn.nukkit.level.generator.Generator;
 import cn.nukkit.level.generator.PopChunkManager;
@@ -10,6 +11,7 @@ import com.google.common.base.Preconditions;
 import lombok.extern.log4j.Log4j2;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.function.BiFunction;
@@ -38,7 +40,7 @@ public class ChunkPopulateFunction implements BiFunction<Chunk, List<Chunk>, Chu
 
         PopChunkManager manager = POP_CHUNK_MANAGER.get();
 
-        List<LockableChunk> lockableChunks = new ArrayList<>();
+        List<LockableChunk> lockableChunks = new ArrayList<>(chunks.size());
         lockableChunks.add(chunk.lockable());
 
         for (Chunk aroundChunk : chunks) {
@@ -55,7 +57,12 @@ public class ChunkPopulateFunction implements BiFunction<Chunk, List<Chunk>, Chu
 
         manager.setSeed(this.level.getSeed());
         lockableChunks.forEach(manager::setChunk);
-        //lockableChunks.forEach(Lock::lock);
+
+        //sort chunks so that locks are always obtained in the same order
+        //this prevents deadlocking when populating neighboring chunks
+        lockableChunks.sort(Comparator.naturalOrder());
+
+        lockableChunks.forEach(Lock::lock);
         try {
             generator.populateChunk(manager, random, chunk.getX(), chunk.getZ());
 
@@ -68,7 +75,7 @@ public class ChunkPopulateFunction implements BiFunction<Chunk, List<Chunk>, Chu
         } finally {
             manager.clean();
             for (LockableChunk lockableChunk : lockableChunks) {
-                //lockableChunk.unlock();
+                lockableChunk.unlock();
                 lockableChunk.setDirty(false);
             }
         }

--- a/src/main/java/cn/nukkit/level/manager/LevelChunkManager.java
+++ b/src/main/java/cn/nukkit/level/manager/LevelChunkManager.java
@@ -37,14 +37,14 @@ public final class LevelChunkManager {
 
     private static final CompletableFuture<Void> COMPLETED_VOID_FUTURE = CompletableFuture.completedFuture(null);
 
-    private final Level level;
+    private final Level         level;
     private final LevelProvider provider;
-    private final Long2ObjectMap<LoadingChunk> chunks = new Long2ObjectOpenHashMap<>();
-    private final Long2LongMap chunkLoadedTimes = new Long2LongOpenHashMap();
-    private final Long2LongMap chunkLastAccessTimes = new Long2LongOpenHashMap();
+    private final Long2ObjectMap<LoadingChunk> chunks               = new Long2ObjectOpenHashMap<>();
+    private final Long2LongMap                 chunkLoadedTimes     = new Long2LongOpenHashMap();
+    private final Long2LongMap                 chunkLastAccessTimes = new Long2LongOpenHashMap();
     private final ChunkGenerateFunction chunkGenerateFunction;
     private final ChunkPopulateFunction chunkPopulateFunction;
-    private final Executor executor;
+    private final Executor              executor;
 
     public LevelChunkManager(Level level) {
         this(level, level.getProvider());
@@ -81,15 +81,16 @@ public final class LevelChunkManager {
     public synchronized Set<Chunk> getLoadedChunks() {
         ImmutableSet.Builder<Chunk> chunks = ImmutableSet.builder();
         for (LoadingChunk loadingChunk : this.chunks.values()) {
-            Chunk chunk = loadingChunk.getChunk();
-            if (chunk != null) {
+            CompletableFuture<Chunk> chunkFuture = loadingChunk.populateAround(true);
+            Chunk chunk;
+            if (chunkFuture != null && (chunk = chunkFuture.getNow(null)) != null) {
                 chunks.add(chunk);
             }
         }
         return chunks.build();
     }
 
-    public synchronized int getLoadedCount() {
+    public int getLoadedCount() {
         return this.chunks.size();
     }
 
@@ -101,8 +102,14 @@ public final class LevelChunkManager {
      */
     @Nullable
     public synchronized Chunk getLoadedChunk(long key) {
-        LoadingChunk chunk = this.chunks.get(key);
-        return chunk == null ? null : chunk.getChunk();
+        LoadingChunk loadingChunk = this.chunks.get(key);
+        if (loadingChunk != null) {
+            CompletableFuture<Chunk> chunkFuture = loadingChunk.populateAround(true);
+            if (chunkFuture != null) {
+                return chunkFuture.getNow(null);
+            }
+        }
+        return null;
     }
 
     /**
@@ -113,8 +120,8 @@ public final class LevelChunkManager {
      * @return chunk or null
      */
     @Nullable
-    public synchronized Chunk getLoadedChunk(int x, int z) {
-        return getLoadedChunk(Chunk.key(x, z));
+    public Chunk getLoadedChunk(int x, int z) {
+        return this.getLoadedChunk(Chunk.key(x, z));
     }
 
     /**
@@ -126,14 +133,9 @@ public final class LevelChunkManager {
      */
     @Nonnull
     public Chunk getChunk(int x, int z) {
-        return this.getChunk(x, z, true);
-    }
-
-    @Nonnull
-    public Chunk getChunk(int x, int z, boolean generate) {
-        Chunk chunk = getLoadedChunk(x, z);
+        Chunk chunk = this.getLoadedChunk(x, z);
         if (chunk == null) {
-            chunk = this.getChunkFuture(x, z, generate).join();
+            chunk = this.getChunkFuture(x, z).join();
         }
         return chunk;
     }
@@ -147,35 +149,77 @@ public final class LevelChunkManager {
      */
     @Nonnull
     public CompletableFuture<Chunk> getChunkFuture(int x, int z) {
-        return this.getChunkFuture(x, z, true);
+        return this.getChunkFuture(x, z, true, true, true);
+    }
+
+    /**
+     * Get chunk future at the specified coordinates without forcing the chunk to be generated.
+     * <p>
+     * This is unsafe, and should not be used without good reason.
+     *
+     * @param x chunk x
+     * @param z chunk z
+     * @return chunk future
+     */
+    @Nonnull
+    public CompletableFuture<Chunk> getLoadedChunkFutureUnsafe(int x, int z) {
+        return this.getChunkFuture(x, z, false, false, false);
+    }
+
+    /**
+     * Get chunk future at the specified coordinates without forcing the chunk to be populated.
+     * <p>
+     * This is unsafe, and should not be used without good reason.
+     *
+     * @param x chunk x
+     * @param z chunk z
+     * @return chunk future
+     */
+    @Nonnull
+    public CompletableFuture<Chunk> getGeneratedChunkFutureUnsafe(int x, int z) {
+        return this.getChunkFuture(x, z, true, false, false);
+    }
+
+    /**
+     * Get chunk future at the specified coordinates without forcing the chunk's population chunks be populated.
+     * <p>
+     * This is unsafe, and should not be used without good reason.
+     *
+     * @param x chunk x
+     * @param z chunk z
+     * @return chunk future
+     */
+    @Nonnull
+    public CompletableFuture<Chunk> getPopulatedChunkFutureUnsafe(int x, int z) {
+        return this.getChunkFuture(x, z, true, true, false);
     }
 
     @Nonnull
-    public CompletableFuture<Chunk> getChunkFuture(int x, int z, boolean generate) {
-        return this.getChunkFuture(x, z, generate, generate);
-    }
-
-    @Nonnull
-    private synchronized CompletableFuture<Chunk> getChunkFuture(int chunkX, int chunkZ, boolean generate,
-                                                                 boolean populate) {
+    private synchronized CompletableFuture<Chunk> getChunkFuture(int chunkX, int chunkZ, boolean generate, boolean populate, boolean populateAround) {
         final long chunkKey = Chunk.key(chunkX, chunkZ);
         this.chunkLastAccessTimes.put(chunkKey, System.currentTimeMillis());
         LoadingChunk chunk = this.chunks.computeIfAbsent(chunkKey, key -> new LoadingChunk(key, true));
 
-        if (generate) {
-            chunk.generate();
+        if (populateAround) {
+            return chunk.populateAround(false);
+        } else if (populate)    {
+            return chunk.populate(false);
+        } else if (generate)    {
+            return chunk.generate(false);
+        } else {
+            return chunk.load();
         }
-
-        if (populate) {
-            chunk.populate();
-        }
-
-        return chunk.getFuture();
     }
 
     public synchronized boolean isChunkLoaded(long hash) {
-        LoadingChunk chunk = this.chunks.get(hash);
-        return chunk != null && chunk.getChunk() != null;
+        LoadingChunk loadingChunk = this.chunks.get(hash);
+        if (loadingChunk != null) {
+            CompletableFuture<Chunk> chunkFuture = loadingChunk.populateAround(true);
+            Chunk chunk;
+            return chunkFuture != null && (chunk = chunkFuture.getNow(null)) != null;
+        } else {
+            return false;
+        }
     }
 
     public synchronized boolean isChunkLoaded(int x, int z) {
@@ -214,14 +258,17 @@ public final class LevelChunkManager {
         if (loadingChunk == null) {
             return false;
         }
-        Chunk chunk = loadingChunk.getChunk();
+        CompletableFuture<Chunk> chunkFuture = loadingChunk.bestFuture();
+        if (chunkFuture == null)  {
+            return false;
+        }
+        Chunk chunk = chunkFuture.getNow(null);
         if (chunk == null) {
             return false;
         }
         if (!chunk.getLoaders().isEmpty()) {
             return false;
         }
-
 
         try (Timing ignored = this.level.timings.doChunkUnload.startTiming()) {
             ChunkUnloadEvent chunkUnloadEvent = new ChunkUnloadEvent(chunk);
@@ -249,9 +296,10 @@ public final class LevelChunkManager {
     public synchronized CompletableFuture<Void> saveChunks() {
         List<CompletableFuture<?>> futures = new ArrayList<>();
         for (LoadingChunk loadingChunk : this.chunks.values()) {
-            Chunk chunk = loadingChunk.getChunk();
-            if (chunk != null) {
-                futures.add(saveChunk(chunk));
+            CompletableFuture<Chunk> chunkFuture = loadingChunk.populateAround(true);
+            Chunk chunk;
+            if (chunkFuture != null && (chunk = chunkFuture.getNow(null)) != null) {
+                futures.add(this.saveChunk(chunk));
             }
         }
 
@@ -272,28 +320,6 @@ public final class LevelChunkManager {
         return COMPLETED_VOID_FUTURE;
     }
 
-    @Nonnull
-    public synchronized CompletableFuture<Chunk> regenerateChunk(int x, int z) {
-        long chunkKey = Chunk.key(x, z);
-        long currentTime = System.currentTimeMillis();
-        this.chunkLastAccessTimes.put(chunkKey, currentTime);
-
-        LoadingChunk chunk = this.chunks.get(chunkKey);
-
-        if (chunk == null) {
-            // No need to load the old chunk
-            chunk = new LoadingChunk(chunkKey, false);
-            this.chunks.put(chunkKey, chunk);
-        } else {
-            chunk.clear();
-        }
-
-        chunk.generate();
-        chunk.populate();
-
-        return chunk.getFuture();
-    }
-
     public synchronized void tick() {
         long time = System.currentTimeMillis();
 
@@ -311,8 +337,10 @@ public final class LevelChunkManager {
                 Long2ObjectMap.Entry<LoadingChunk> entry = iterator.next();
                 long chunkKey = entry.getLongKey();
                 LoadingChunk loadingChunk = entry.getValue();
-                Chunk chunk = loadingChunk.getChunk();
-                if (chunk == null) {
+
+                CompletableFuture<Chunk> chunkFuture = loadingChunk.bestFuture();
+                Chunk chunk;
+                if (chunkFuture == null || (chunk = chunkFuture.getNow(null)) == null) {
                     continue; // Chunk hasn't loaded
                 }
 
@@ -336,9 +364,9 @@ public final class LevelChunkManager {
                 if (this.unloadChunk0(chunkKey, true, true)) {
                     iterator.remove();
 
-//                    if (log.isTraceEnabled()) {
-//                        log.trace("Cleared chunk ({},{}) from {}", chunk.getX(), chunk.getZ(), level.getId());
-//                    }
+                    //                    if (log.isTraceEnabled()) {
+                    //                        log.trace("Cleared chunk ({},{}) from {}", chunk.getX(), chunk.getZ(), level.getId());
+                    //                    }
                 }
             }
         }
@@ -346,18 +374,19 @@ public final class LevelChunkManager {
 
     @ToString
     private class LoadingChunk {
-        private final int x;
-        private final int z;
-        private CompletableFuture<Chunk> future;
-        private volatile boolean generated;
-        private volatile boolean populated;
+        private final CompletableFuture<Chunk> loadFuture;
+        private       CompletableFuture<Chunk> generateFuture;
+        private       CompletableFuture<Chunk> populateFuture;
+        private       CompletableFuture<Chunk> populateAroundFuture;
+        private final int                      x;
+        private final int                      z;
 
         public LoadingChunk(long key, boolean load) {
             this.x = Chunk.fromKeyX(key);
             this.z = Chunk.fromKeyZ(key);
 
             if (load) {
-                this.future = LevelChunkManager.this.provider.readChunk(new ChunkBuilder(x, z, LevelChunkManager.this.level))
+                this.loadFuture = LevelChunkManager.this.provider.readChunk(new ChunkBuilder(x, z, LevelChunkManager.this.level))
                         .thenApply(chunk -> {
                             if (chunk == null) {
                                 return new Chunk(this.x, this.z, LevelChunkManager.this.level);
@@ -365,7 +394,7 @@ public final class LevelChunkManager {
                             chunk.init();
                             return chunk;
                         });
-                this.future.whenComplete((chunk, throwable) -> {
+                this.loadFuture.whenComplete((chunk, throwable) -> {
                     if (throwable != null) {
                         log.warn(new ParameterizedMessage("Unable to load chunk ({}, {}) in level {} ",
                                 this.x, this.z, LevelChunkManager.this.level.getId()), throwable);
@@ -380,63 +409,81 @@ public final class LevelChunkManager {
                     }
                 });
             } else {
-                this.future = CompletableFuture.completedFuture(new Chunk(x, z, LevelChunkManager.this.level));
+                this.loadFuture = CompletableFuture.completedFuture(new Chunk(x, z, LevelChunkManager.this.level));
             }
         }
 
-        public CompletableFuture<Chunk> getFuture() {
-            return future;
+        private CompletableFuture<Chunk> load() {
+            return this.loadFuture;
         }
 
-        @Nullable
-        private Chunk getChunk() {
-            return future.getNow(null);
-        }
-
-        private void generate() {
-            if (generated) {
-                Chunk chunk = getChunk();
-                if (chunk == null || chunk.isGenerated()) {
-                    return;
-                }
+        private CompletableFuture<Chunk> generate(boolean skipCreate) {
+            if (skipCreate || this.generateFuture != null) {
+                return this.generateFuture;
             }
-            generated = true;
 
-            future = future.thenApplyAsync(LevelChunkManager.this.chunkGenerateFunction, LevelChunkManager.this.executor);
+            return this.generateFuture = this.load()
+                    .thenApplyAsync(LevelChunkManager.this.chunkGenerateFunction, LevelChunkManager.this.executor);
         }
 
-        private void populate() {
-            this.generate(); // Generation has to happen before population
-
-            if (populated) {
-                Chunk chunk = getChunk();
-                if (chunk == null || chunk.isPopulated()) {
-                    return;
-                }
+        private CompletableFuture<Chunk> populate(boolean skipCreate) {
+            if (skipCreate || this.populateFuture != null) {
+                return this.populateFuture;
             }
-            populated = true;
+
+            CompletableFuture<Chunk> generateFuture = this.generate(false); // Generation has to happen before population
 
             // Load and generate chunks around the chunk to be populated.
             List<CompletableFuture<Chunk>> chunksToLoad = new ArrayList<>(8);
             for (int z = this.z - 1, maxZ = this.z + 1; z <= maxZ; z++) {
                 for (int x = this.x - 1, maxX = this.x + 1; x <= maxX; x++) {
                     if (x == this.x && z == this.z) continue;
-                    chunksToLoad.add(LevelChunkManager.this.getChunkFuture(x, z, true, false));
+                    chunksToLoad.add(LevelChunkManager.this.getChunkFuture(x, z, true, false, false));
                 }
             }
             CompletableFuture<List<Chunk>> aroundFuture = CompletableFutures.allAsList(chunksToLoad);
 
-            future = future.thenCombineAsync(aroundFuture, LevelChunkManager.this.chunkPopulateFunction,
-                    LevelChunkManager.this.executor);
+            return this.populateFuture = generateFuture
+                    .thenCombineAsync(aroundFuture, LevelChunkManager.this.chunkPopulateFunction, LevelChunkManager.this.executor);
         }
 
-        private void clear() {
-            this.generated = false;
-            this.populated = false;
-            this.future = future.thenApply(chunk -> {
-                chunk.clear();
-                return chunk;
-            });
+        private CompletableFuture<Chunk> populateAround(boolean skipCreate) {
+            if (skipCreate || this.populateAroundFuture != null) {
+                return this.populateAroundFuture;
+            }
+
+            // Load and generate chunks around the chunk to be populated.
+            List<CompletableFuture<Chunk>> chunksToLoad = new ArrayList<>(9);
+            chunksToLoad.add(this.populate(false));
+            for (int z = this.z - 1, maxZ = this.z + 1; z <= maxZ; z++) {
+                for (int x = this.x - 1, maxX = this.x + 1; x <= maxX; x++) {
+                    if (x == this.x && z == this.z) {
+                        continue;
+                    }
+                    chunksToLoad.add(LevelChunkManager.this.getChunkFuture(x, z, true, true, false));
+                }
+            }
+
+            return this.populateAroundFuture = CompletableFutures.allAsList(chunksToLoad)
+                    .thenApply(chunks -> {
+                        Chunk chunk = chunks.get(0);
+                        if (!chunk.isPopulatedAround()) {
+                            throw new IllegalStateException("Chunk was not populated around!");
+                        }
+                        return chunk;
+                    });
+        }
+
+        private CompletableFuture<Chunk> bestFuture() {
+            if (this.populateAroundFuture != null) {
+                return this.populateAroundFuture;
+            } else if (this.populateFuture != null) {
+                return this.populateFuture;
+            } else if (this.generateFuture != null) {
+                return this.generateFuture;
+            } else {
+                return this.loadFuture;
+            }
         }
     }
 }

--- a/src/main/java/cn/nukkit/registry/RegistryProvider.java
+++ b/src/main/java/cn/nukkit/registry/RegistryProvider.java
@@ -20,7 +20,6 @@ public class RegistryProvider<T> implements Comparable<RegistryProvider<T>> {
         return value;
     }
 
-    @Nonnull
     public Plugin getPlugin() {
         return plugin;
     }


### PR DESCRIPTION
Result of a long internal discussion about the best way to handle the issues caused by not all chunks being saved any more.

Prevents users from getting access to chunks that haven't been populated themselves, or had their neighbor chunks populated.

This is still not entirely safe, but it's a lot better than before, the remaining edge cases will be worked out in #1073 .