### PR TITLE
[2.0] Adds Barrier block

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockBarrier.java
+++ b/src/main/java/cn/nukkit/block/BlockBarrier.java
@@ -1,0 +1,49 @@
+package cn.nukkit.block;
+
+import cn.nukkit.item.Item;
+import cn.nukkit.utils.BlockColor;
+import cn.nukkit.utils.Identifier;
+
+public class BlockBarrier extends BlockSolid {
+
+    public BlockBarrier(Identifier id) {
+        super(id);
+    }
+
+    // Waiting for waterlogging be implemented.
+    /*@Override
+    public int getWaterloggingLevel() {
+        return 1;
+    }
+
+    @Override
+    public boolean canBeFlowedInto() {
+        return false;
+    }*/
+
+    @Override
+    public double getHardness() {
+        return -1;
+    }
+
+    @Override
+    public double getResistance() {
+        return 18000000;
+    }
+
+    @Override
+    public boolean isBreakable(Item item) {
+        return false;
+    }
+
+    @Override
+    public BlockColor getColor() {
+        return BlockColor.TRANSPARENT_BLOCK_COLOR;
+    }
+
+    @Override
+    public boolean canBePushed() {
+        return false;
+    }
+
+}

--- a/src/main/java/cn/nukkit/registry/BlockRegistry.java
+++ b/src/main/java/cn/nukkit/registry/BlockRegistry.java
@@ -524,5 +524,7 @@ public class BlockRegistry implements Registry {
         this.factoryMap.put(RED_NETHER_BRICK_STAIRS, BlockStairsNetherBrick::new); //439
 
         this.factoryMap.put(SMOOTH_QUARTZ_STAIRS, BlockStairsQuartz::new); //440
+
+        this.factoryMap.put(BARRIER, BlockBarrier::new); //415
     }
 }


### PR DESCRIPTION
So the barrier properties are respected.

For example, a TNT could blow and drop it without this change.

Reference: GameModsBr#135