### PR TITLE
[2.0] Fixes block entities not being saved before LevelDB serialization

### DIFF
--- a/src/main/java/cn/nukkit/level/provider/leveldb/serializer/BlockEntitySerializer.java
+++ b/src/main/java/cn/nukkit/level/provider/leveldb/serializer/BlockEntitySerializer.java
@@ -53,6 +53,7 @@ public class BlockEntitySerializer {
         byte[] value;
         try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
             for (BlockEntity entity : entities) {
+                entity.saveNBT();
                 NBTIO.write(entity.namedTag, stream, ByteOrder.LITTLE_ENDIAN);
             }
             value = stream.toByteArray();


### PR DESCRIPTION
Reference: GameModsBr#147