### PR TITLE
[2.0] Fix the dropped button's damage value when a button is broken

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockButton.java
+++ b/src/main/java/cn/nukkit/block/BlockButton.java
@@ -120,7 +120,7 @@ public abstract class BlockButton extends FloodableBlock implements Faceable {
 
     @Override
     public Item toItem() {
-        return Item.get(this.getId(), 5);
+        return Item.get(this.getId(), 0);
     }
 
     @Override


### PR DESCRIPTION
Steps to reproduce the bug:
1. `/give <your-nick> wooden_button` (or get in creative mode)
2. Place the button somewhere
3. Break the button in survival mode
4. Notice that the button won't stack with the other `63` buttons of the same type.

Reference: GameModsBr#165