### PR TITLE
[2.0] Fix stone_button break time and dropping without pickaxe

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockButtonStone.java
+++ b/src/main/java/cn/nukkit/block/BlockButtonStone.java
@@ -1,5 +1,6 @@
 package cn.nukkit.block;
 
+import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemTool;
 import cn.nukkit.utils.Identifier;
 
@@ -15,5 +16,19 @@ public class BlockButtonStone extends BlockButton {
     @Override
     public int getToolType() {
         return ItemTool.TYPE_PICKAXE;
+    }
+
+    @Override
+    public boolean canHarvestWithHand() {
+        return false;
+    }
+
+    @Override
+    public Item[] getDrops(Item item) {
+        if (item.isPickaxe()) {
+            return super.getDrops(item);
+        } else {
+            return new Item[0];
+        }
     }
 }


### PR DESCRIPTION
Steps to reproduce the bug:
1. `/give <your-nick> stone_button`
2. Place the button somewhere
3. Break the button in survival mode with your hands
4. Notice that the button breaks quicker than it should and drops as an item while it should be destroyed

Reference: GameModsBr#166