### PR TITLE
[2.0] Fixes primed TNT and TNT minecarts not blinking and growing when lit

### DIFF
--- a/src/main/java/cn/nukkit/entity/impl/misc/EntityTnt.java
+++ b/src/main/java/cn/nukkit/entity/impl/misc/EntityTnt.java
@@ -107,7 +107,7 @@ public class EntityTnt extends BaseEntity implements Tnt, EntityExplosive {
             return true;
         }
 
-        if (fuse % 5 == 0) {
+        if (fuse <= 5 || fuse % 5 == 0) {
             this.setIntData(FUSE_LENGTH, fuse);
 
             updateData();

--- a/src/main/java/cn/nukkit/entity/impl/misc/EntityTnt.java
+++ b/src/main/java/cn/nukkit/entity/impl/misc/EntityTnt.java
@@ -109,6 +109,8 @@ public class EntityTnt extends BaseEntity implements Tnt, EntityExplosive {
 
         if (fuse % 5 == 0) {
             this.setIntData(FUSE_LENGTH, fuse);
+
+            updateData();
         }
 
         lastUpdate = currentTick;

--- a/src/main/java/cn/nukkit/entity/impl/vehicle/EntityTntMinecart.java
+++ b/src/main/java/cn/nukkit/entity/impl/vehicle/EntityTntMinecart.java
@@ -68,6 +68,8 @@ public class EntityTntMinecart extends EntityAbstractMinecart implements TntMine
 
             if (fuse % 5 == 0) {
                 setIntData(FUSE_LENGTH, fuse);
+
+                updateData();
             }
 
             fuse -= tickDiff;
@@ -83,7 +85,7 @@ public class EntityTntMinecart extends EntityAbstractMinecart implements TntMine
 
         this.timing.stopTiming();
 
-        return super.onUpdate(currentTick);
+        return super.onUpdate(currentTick) || fuse < 80;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/impl/vehicle/EntityTntMinecart.java
+++ b/src/main/java/cn/nukkit/entity/impl/vehicle/EntityTntMinecart.java
@@ -66,7 +66,7 @@ public class EntityTntMinecart extends EntityAbstractMinecart implements TntMine
 
             lastUpdate = currentTick;
 
-            if (fuse % 5 == 0) {
+            if (fuse <= 5 || fuse % 5 == 0) {
                 setIntData(FUSE_LENGTH, fuse);
 
                 updateData();


### PR DESCRIPTION
Primed TNTs were white all the time and wasn't growing in the last second before exploding.

Primed TNT minecarts were not working correctly and they were exploding kinda randomly on player interactions.

History and reference: GameModsBr#169