### PR TITLE
[2.0] Waterlogging fixes and improvements

### DIFF
--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -724,7 +724,11 @@ public abstract class Block extends BlockPosition implements Metadatable, Clonea
         return false;
     }
 
-    public boolean canWaterlog() {
+    public boolean canWaterlogSource() {
+        return false;
+    }
+
+    public boolean canWaterlogFlowing() {
         return false;
     }
 

--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -503,7 +503,7 @@ public abstract class Block extends BlockPosition implements Metadatable, Clonea
 
     @Override
     public String toString() {
-        return String.format("Block(id=%s, data=%s, position=(%d, %d, %d))", this.id, this.meta, this.x, this.y, this.z);
+        return String.format("Block(id=%s, data=%s, position=(%d, %d, %d, %d))", this.id, this.meta, this.x, this.y, this.z, this.layer);
     }
 
     public boolean collidesWithBB(AxisAlignedBB bb) {
@@ -726,10 +726,6 @@ public abstract class Block extends BlockPosition implements Metadatable, Clonea
 
     public boolean canWaterlog() {
         return false;
-    }
-
-    public void onWaterlog() {
-
     }
 
     public boolean isWaterlogged() {

--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -126,12 +126,16 @@ public abstract class Block extends BlockPosition implements Metadatable, Clonea
     }
 
     public boolean onBreak(Item item) {
+        return removeBlock(true);
+    }
+
+    final protected boolean removeBlock(boolean update) {
         if (this.isWaterlogged()) {
             Block water = getLevel().getBlock(getX(), getY(), getZ(), 1);
-            getLevel().setBlock(getX(), getY(), getZ(), 1, Block.get(AIR), true, false);
-            return getLevel().setBlock(this, water, true, true);
+            getLevel().setBlock(this, water, true, false);
+            return getLevel().setBlock(getX(), getY(), getZ(), 1, Block.get(AIR), true, update);
         }
-        return this.getLevel().setBlock(this, Block.get(AIR), true, true);
+        return this.getLevel().setBlock(this, Block.get(AIR), true, update);
     }
 
     public boolean onBreak(Item item, Player player) {

--- a/src/main/java/cn/nukkit/block/BlockAnvil.java
+++ b/src/main/java/cn/nukkit/block/BlockAnvil.java
@@ -114,4 +114,9 @@ public class BlockAnvil extends BlockFallable implements Faceable {
     public BlockFace getBlockFace() {
         return BlockFace.fromHorizontalIndex(this.getDamage() & 0x7);
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockBanner.java
+++ b/src/main/java/cn/nukkit/block/BlockBanner.java
@@ -144,4 +144,9 @@ public class BlockBanner extends BlockTransparent implements Faceable {
 
         return DyeColor.WHITE;
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockBarrier.java
+++ b/src/main/java/cn/nukkit/block/BlockBarrier.java
@@ -10,16 +10,10 @@ public class BlockBarrier extends BlockSolid {
         super(id);
     }
 
-    // Waiting for waterlogging be implemented.
-    /*@Override
-    public int getWaterloggingLevel() {
-        return 1;
-    }
-
     @Override
-    public boolean canBeFlowedInto() {
-        return false;
-    }*/
+    public boolean canWaterlog() {
+        return true;
+    }
 
     @Override
     public double getHardness() {

--- a/src/main/java/cn/nukkit/block/BlockBarrier.java
+++ b/src/main/java/cn/nukkit/block/BlockBarrier.java
@@ -11,7 +11,7 @@ public class BlockBarrier extends BlockSolid {
     }
 
     @Override
-    public boolean canWaterlog() {
+    public boolean canWaterlogSource() {
         return true;
     }
 

--- a/src/main/java/cn/nukkit/block/BlockBeacon.java
+++ b/src/main/java/cn/nukkit/block/BlockBeacon.java
@@ -95,4 +95,9 @@ public class BlockBeacon extends BlockTransparent {
     public BlockColor getColor() {
         return BlockColor.DIAMOND_BLOCK_COLOR;
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockBed.java
+++ b/src/main/java/cn/nukkit/block/BlockBed.java
@@ -132,31 +132,34 @@ public class BlockBed extends BlockTransparent implements Faceable {
         Block blockWest = this.west();
 
         Block air = Block.get(AIR);
-
+        Block otherPart = null;
         if ((this.getDamage() & 0x08) == 0x08) { //This is the Top part of bed
             if (blockNorth.getId() == BED && (blockNorth.getDamage() & 0x08) != 0x08) { //Checks if the block ID&&meta are right
-                this.getLevel().setBlock(blockNorth, air, true, true);
+                otherPart = blockNorth;
             } else if (blockSouth.getId() == BED && (blockSouth.getDamage() & 0x08) != 0x08) {
-                this.getLevel().setBlock(blockSouth, air, true, true);
+                otherPart = blockSouth;
             } else if (blockEast.getId() == BED && (blockEast.getDamage() & 0x08) != 0x08) {
-                this.getLevel().setBlock(blockEast, air, true, true);
+                otherPart = blockEast;
             } else if (blockWest.getId() == BED && (blockWest.getDamage() & 0x08) != 0x08) {
-                this.getLevel().setBlock(blockWest, air, true, true);
+                otherPart = blockWest;
             }
         } else { //Bottom Part of Bed
             if (blockNorth.getId() == this.getId() && (blockNorth.getDamage() & 0x08) == 0x08) {
-                this.getLevel().setBlock(blockNorth, air, true, true);
+                otherPart = blockNorth;
             } else if (blockSouth.getId() == this.getId() && (blockSouth.getDamage() & 0x08) == 0x08) {
-                this.getLevel().setBlock(blockSouth, air, true, true);
+                otherPart = blockSouth;
             } else if (blockEast.getId() == this.getId() && (blockEast.getDamage() & 0x08) == 0x08) {
-                this.getLevel().setBlock(blockEast, air, true, true);
+                otherPart = blockEast;
             } else if (blockWest.getId() == this.getId() && (blockWest.getDamage() & 0x08) == 0x08) {
-                this.getLevel().setBlock(blockWest, air, true, true);
+                otherPart = blockWest;
             }
         }
 
-        this.getLevel().setBlock(this, air, true, false); // Do not update both parts to prevent duplication bug if there is two fallable blocks top of the bed
+        if (otherPart instanceof BlockBed) {
+            otherPart.removeBlock(false); // Do not update both parts to prevent duplication bug if there is two fallable blocks top of the bed
+        }
 
+        removeBlock(true);
         return true;
     }
 

--- a/src/main/java/cn/nukkit/block/BlockBed.java
+++ b/src/main/java/cn/nukkit/block/BlockBed.java
@@ -110,6 +110,9 @@ public class BlockBed extends BlockTransparent implements Faceable {
                 int meta = player.getDirection().getHorizontalIndex();
 
                 this.getLevel().setBlock(block, Block.get(this.getId(), meta), true, true);
+                if (next instanceof BlockLiquid && ((BlockLiquid) next).usesWaterLogging()) {
+                    this.getLevel().setBlock(next.layer(1), next, true, false);
+                }
                 this.getLevel().setBlock(next, Block.get(this.getId(), meta | 0x08), true, true);
 
                 createBlockEntity(this, item.getDamage());

--- a/src/main/java/cn/nukkit/block/BlockBed.java
+++ b/src/main/java/cn/nukkit/block/BlockBed.java
@@ -111,7 +111,7 @@ public class BlockBed extends BlockTransparent implements Faceable {
 
                 this.getLevel().setBlock(block, Block.get(this.getId(), meta), true, true);
                 if (next instanceof BlockLiquid && ((BlockLiquid) next).usesWaterLogging()) {
-                    this.getLevel().setBlock(next.layer(1), next, true, false);
+                    this.getLevel().setBlock(next.layer(1), next.clone(), true, false);
                 }
                 this.getLevel().setBlock(next, Block.get(this.getId(), meta | 0x08), true, true);
 

--- a/src/main/java/cn/nukkit/block/BlockBed.java
+++ b/src/main/java/cn/nukkit/block/BlockBed.java
@@ -190,4 +190,9 @@ public class BlockBed extends BlockTransparent implements Faceable {
     public BlockFace getBlockFace() {
         return BlockFace.fromHorizontalIndex(this.getDamage() & 0x7);
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockBrewingStand.java
+++ b/src/main/java/cn/nukkit/block/BlockBrewingStand.java
@@ -148,4 +148,9 @@ public class BlockBrewingStand extends BlockSolid {
     public boolean canHarvestWithHand() {
         return false;
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockButton.java
+++ b/src/main/java/cn/nukkit/block/BlockButton.java
@@ -127,4 +127,9 @@ public abstract class BlockButton extends FloodableBlock implements Faceable {
     public BlockFace getBlockFace() {
         return BlockFace.fromHorizontalIndex(this.getDamage() & 0x7);
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockCactus.java
+++ b/src/main/java/cn/nukkit/block/BlockCactus.java
@@ -123,7 +123,7 @@ public class BlockCactus extends BlockTransparent {
     @Override
     public boolean place(Item item, Block block, Block target, BlockFace face, Vector3f clickPos, Player player) {
         Block down = this.down();
-        if (down.getId() == SAND || down.getId() == CACTUS) {
+        if (!block.isWaterlogged() && (down.getId() == SAND || down.getId() == CACTUS)) {
             Block block0 = north();
             Block block1 = south();
             Block block2 = west();

--- a/src/main/java/cn/nukkit/block/BlockCactus.java
+++ b/src/main/java/cn/nukkit/block/BlockCactus.java
@@ -148,4 +148,9 @@ public class BlockCactus extends BlockTransparent {
                 Item.get(CACTUS, 0, 1)
         };
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockCake.java
+++ b/src/main/java/cn/nukkit/block/BlockCake.java
@@ -126,4 +126,9 @@ public class BlockCake extends BlockTransparent {
     public boolean hasComparatorInputOverride() {
         return true;
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockCampfire.java
+++ b/src/main/java/cn/nukkit/block/BlockCampfire.java
@@ -104,7 +104,7 @@ public class BlockCampfire extends BlockSolid implements Faceable {
     }
 
     @Override
-    public boolean canWaterlog() {
+    public boolean canWaterlogSource() {
         return true;
     }
 

--- a/src/main/java/cn/nukkit/block/BlockCampfire.java
+++ b/src/main/java/cn/nukkit/block/BlockCampfire.java
@@ -11,6 +11,7 @@ import cn.nukkit.item.ItemEdible;
 import cn.nukkit.item.ItemIds;
 import cn.nukkit.item.ItemTool;
 import cn.nukkit.item.enchantment.Enchantment;
+import cn.nukkit.level.Level;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.math.Vector3f;
 import cn.nukkit.nbt.tag.CompoundTag;
@@ -113,13 +114,6 @@ public class BlockCampfire extends BlockSolid implements Faceable {
     }
 
     @Override
-    public void onWaterlog() {
-        if (this.isLit()) {
-            this.toggleFire();
-        }
-    }
-
-    @Override
     public boolean onActivate(Item item) {
         return this.onActivate(item, null);
     }
@@ -173,12 +167,22 @@ public class BlockCampfire extends BlockSolid implements Faceable {
 
     @Override
     public int onUpdate(int type) {
-        if (this.isLit()
-                && (this.up().getId() == BlockIds.WATER
-                || this.up().getId() == BlockIds.FLOWING_WATER
-                || this.isWaterlogged())) {
-            this.toggleFire();
+        if (type == Level.BLOCK_UPDATE_NORMAL) {
+            if (this.isLit()) {
+                if (this.isWaterlogged()) {
+                    this.toggleFire();
+                    return type;
+                }
+
+                Block up = this.up();
+                if (up.getId() == BlockIds.WATER || up.getId() == BlockIds.FLOWING_WATER) {
+                    this.toggleFire();
+                    return type;
+                }
+            }
+            return type;
         }
-        return super.onUpdate(type);
+
+        return 0;
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockCarpet.java
+++ b/src/main/java/cn/nukkit/block/BlockCarpet.java
@@ -83,4 +83,8 @@ public class BlockCarpet extends FloodableBlock {
         return DyeColor.getByWoolData(getDamage());
     }
 
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockCauldron.java
+++ b/src/main/java/cn/nukkit/block/BlockCauldron.java
@@ -61,15 +61,22 @@ public class BlockCauldron extends BlockSolid {
     @Override
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_NORMAL) {
-            if (isWaterlogged()) {
+            Block up = this.up();
+            if (up.getId() == BlockIds.FLOWING_WATER || up.getId() == BlockIds.WATER || up.isWaterlogged()) {
                 if (this.getDamage() != 6) {
                     this.setDamage(6);
-                    this.getLevel().setBlock(this, this, true);
+                    this.level.setBlock(this, this, true);
+                    this.getLevel().addSound(this.add(0.5, 1, 0.5), Sound.CAULDRON_TAKEWATER);
                 }
                 BlockEntity be = this.level.getBlockEntity(this);
                 if (be instanceof BlockEntityCauldron) {
                     BlockEntityCauldron cauldron = (BlockEntityCauldron) be;
-                    cauldron.clearCustomColor();
+                    if (cauldron.getPotionId() != 0xffff) {
+                        cauldron.setPotionId(0xffff);
+                    }
+                    if (cauldron.isCustomColor()) {
+                        cauldron.clearCustomColor();
+                    }
                 }
             }
             return type;
@@ -265,10 +272,5 @@ public class BlockCauldron extends BlockSolid {
     @Override
     public boolean canHarvestWithHand() {
         return false;
-    }
-
-    @Override
-    public boolean canWaterlogSource() {
-        return true;
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockCauldron.java
+++ b/src/main/java/cn/nukkit/block/BlockCauldron.java
@@ -8,7 +8,6 @@ import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBucket;
 import cn.nukkit.item.ItemIds;
 import cn.nukkit.item.ItemTool;
-import cn.nukkit.level.Level;
 import cn.nukkit.level.Sound;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.math.Vector3f;
@@ -56,33 +55,6 @@ public class BlockCauldron extends BlockSolid {
 
     public boolean isEmpty() {
         return this.getDamage() == 0x00;
-    }
-
-    @Override
-    public int onUpdate(int type) {
-        if (type == Level.BLOCK_UPDATE_NORMAL) {
-            Block up = this.up();
-            if (up.getId() == BlockIds.FLOWING_WATER || up.getId() == BlockIds.WATER || up.isWaterlogged()) {
-                if (this.getDamage() != 6) {
-                    this.setDamage(6);
-                    this.level.setBlock(this, this, true);
-                    this.level.addSound(this.add(0.5, 1, 0.5), Sound.CAULDRON_TAKEWATER);
-                }
-                BlockEntity be = this.level.getBlockEntity(this);
-                if (be instanceof BlockEntityCauldron) {
-                    BlockEntityCauldron cauldron = (BlockEntityCauldron) be;
-                    if (cauldron.hasPotion()) {
-                        cauldron.setPotionId(0xffff);
-                    }
-                    if (cauldron.isCustomColor()) {
-                        cauldron.clearCustomColor();
-                    }
-                }
-            }
-            return type;
-        }
-
-        return 0;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockCauldron.java
+++ b/src/main/java/cn/nukkit/block/BlockCauldron.java
@@ -8,6 +8,7 @@ import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBucket;
 import cn.nukkit.item.ItemIds;
 import cn.nukkit.item.ItemTool;
+import cn.nukkit.level.Level;
 import cn.nukkit.level.Sound;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.math.Vector3f;
@@ -55,6 +56,26 @@ public class BlockCauldron extends BlockSolid {
 
     public boolean isEmpty() {
         return this.getDamage() == 0x00;
+    }
+
+    @Override
+    public int onUpdate(int type) {
+        if (type == Level.BLOCK_UPDATE_NORMAL) {
+            if (isWaterlogged()) {
+                if (this.getDamage() != 6) {
+                    this.setDamage(6);
+                    this.getLevel().setBlock(this, this, true);
+                }
+                BlockEntity be = this.level.getBlockEntity(this);
+                if (be instanceof BlockEntityCauldron) {
+                    BlockEntityCauldron cauldron = (BlockEntityCauldron) be;
+                    cauldron.clearCustomColor();
+                }
+            }
+            return type;
+        }
+
+        return 0;
     }
 
     @Override
@@ -244,5 +265,10 @@ public class BlockCauldron extends BlockSolid {
     @Override
     public boolean canHarvestWithHand() {
         return false;
+    }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockCauldron.java
+++ b/src/main/java/cn/nukkit/block/BlockCauldron.java
@@ -66,7 +66,7 @@ public class BlockCauldron extends BlockSolid {
                 if (this.getDamage() != 6) {
                     this.setDamage(6);
                     this.level.setBlock(this, this, true);
-                    this.getLevel().addSound(this.add(0.5, 1, 0.5), Sound.CAULDRON_TAKEWATER);
+                    this.level.addSound(this.add(0.5, 1, 0.5), Sound.CAULDRON_TAKEWATER);
                 }
                 BlockEntity be = this.level.getBlockEntity(this);
                 if (be instanceof BlockEntityCauldron) {

--- a/src/main/java/cn/nukkit/block/BlockCauldron.java
+++ b/src/main/java/cn/nukkit/block/BlockCauldron.java
@@ -71,7 +71,7 @@ public class BlockCauldron extends BlockSolid {
                 BlockEntity be = this.level.getBlockEntity(this);
                 if (be instanceof BlockEntityCauldron) {
                     BlockEntityCauldron cauldron = (BlockEntityCauldron) be;
-                    if (cauldron.getPotionId() != 0xffff) {
+                    if (cauldron.hasPotion()) {
                         cauldron.setPotionId(0xffff);
                     }
                     if (cauldron.isCustomColor()) {

--- a/src/main/java/cn/nukkit/block/BlockChest.java
+++ b/src/main/java/cn/nukkit/block/BlockChest.java
@@ -31,7 +31,7 @@ public class BlockChest extends BlockTransparent implements Faceable {
     }
 
     @Override
-    public boolean canWaterlog() {
+    public boolean canWaterlogSource() {
         return true;
     }
 

--- a/src/main/java/cn/nukkit/block/BlockCobweb.java
+++ b/src/main/java/cn/nukkit/block/BlockCobweb.java
@@ -56,4 +56,9 @@ public class BlockCobweb extends FloodableBlock {
     public boolean canHarvestWithHand() {
         return false;
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockCocoa.java
+++ b/src/main/java/cn/nukkit/block/BlockCocoa.java
@@ -235,4 +235,14 @@ public class BlockCocoa extends BlockTransparent implements Faceable {
     public BlockFace getBlockFace() {
         return BlockFace.fromHorizontalIndex(this.getDamage() & 0x07);
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
+
+    @Override
+    public boolean canWaterlogFlowing() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockDaylightDetector.java
+++ b/src/main/java/cn/nukkit/block/BlockDaylightDetector.java
@@ -34,6 +34,11 @@ public class BlockDaylightDetector extends BlockTransparent {
         return false;
     }
 
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
+
     //todo redstone
 
 }

--- a/src/main/java/cn/nukkit/block/BlockDaylightDetectorInverted.java
+++ b/src/main/java/cn/nukkit/block/BlockDaylightDetectorInverted.java
@@ -24,4 +24,8 @@ public class BlockDaylightDetectorInverted extends BlockDaylightDetector {
         return true;
     }
 
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockDeadBush.java
+++ b/src/main/java/cn/nukkit/block/BlockDeadBush.java
@@ -68,4 +68,9 @@ public class BlockDeadBush extends FloodableBlock {
     public BlockColor getColor() {
         return BlockColor.FOLIAGE_BLOCK_COLOR;
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockDoor.java
+++ b/src/main/java/cn/nukkit/block/BlockDoor.java
@@ -234,6 +234,9 @@ public abstract class BlockDoor extends BlockTransparent implements Faceable {
 
             this.setDamage(direction);
             this.getLevel().setBlock(block, this, true, false); //Bottom
+            if (blockUp instanceof BlockLiquid && ((BlockLiquid) blockUp).usesWaterLogging()) {
+                this.getLevel().setBlock(blockUp.layer(1), blockUp, true, false);
+            }
             this.getLevel().setBlock(blockUp, Block.get(this.getId(), metaUp), true, true); //Top
 
             if (!this.isOpen() && this.level.isBlockPowered(this.asVector3i())) {

--- a/src/main/java/cn/nukkit/block/BlockDoor.java
+++ b/src/main/java/cn/nukkit/block/BlockDoor.java
@@ -256,15 +256,16 @@ public abstract class BlockDoor extends BlockTransparent implements Faceable {
         if (isTop(this.getDamage())) {
             Block down = this.down();
             if (down.getId() == this.getId()) {
-                this.getLevel().setBlock(down, Block.get(AIR), true);
+                down.removeBlock(true);
             }
         } else {
             Block up = this.up();
             if (up.getId() == this.getId()) {
-                this.getLevel().setBlock(up, Block.get(AIR), true);
+                up.removeBlock(true);
             }
         }
-        this.getLevel().setBlock(this, Block.get(AIR), true);
+
+        super.onBreak(item);
 
         return true;
     }

--- a/src/main/java/cn/nukkit/block/BlockDoor.java
+++ b/src/main/java/cn/nukkit/block/BlockDoor.java
@@ -235,7 +235,7 @@ public abstract class BlockDoor extends BlockTransparent implements Faceable {
             this.setDamage(direction);
             this.getLevel().setBlock(block, this, true, false); //Bottom
             if (blockUp instanceof BlockLiquid && ((BlockLiquid) blockUp).usesWaterLogging()) {
-                this.getLevel().setBlock(blockUp.layer(1), blockUp, true, false);
+                this.getLevel().setBlock(blockUp.layer(1), blockUp.clone(), true, false);
             }
             this.getLevel().setBlock(blockUp, Block.get(this.getId(), metaUp), true, true); //Top
 

--- a/src/main/java/cn/nukkit/block/BlockDoor.java
+++ b/src/main/java/cn/nukkit/block/BlockDoor.java
@@ -330,4 +330,9 @@ public abstract class BlockDoor extends BlockTransparent implements Faceable {
     public BlockFace getBlockFace() {
         return BlockFace.fromHorizontalIndex(this.getDamage() & 0x07);
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockDragonEgg.java
+++ b/src/main/java/cn/nukkit/block/BlockDragonEgg.java
@@ -68,4 +68,9 @@ public class BlockDragonEgg extends BlockFallable {
             }
         }
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockEnchantingTable.java
+++ b/src/main/java/cn/nukkit/block/BlockEnchantingTable.java
@@ -128,4 +128,9 @@ public class BlockEnchantingTable extends BlockTransparent {
     public BlockColor getColor() {
         return BlockColor.RED_BLOCK_COLOR;
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockEndPortalFrame.java
+++ b/src/main/java/cn/nukkit/block/BlockEndPortalFrame.java
@@ -93,4 +93,9 @@ public class BlockEndPortalFrame extends BlockTransparent implements Faceable {
     public BlockColor getColor() {
         return BlockColor.GREEN_BLOCK_COLOR;
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockEndRod.java
+++ b/src/main/java/cn/nukkit/block/BlockEndRod.java
@@ -83,4 +83,13 @@ public class BlockEndRod extends BlockTransparent implements Faceable {
         return BlockFace.fromHorizontalIndex(this.getDamage() & 0x07);
     }
 
+    @Override
+    public boolean canWaterlogFlowing() {
+        return true;
+    }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockEnderChest.java
+++ b/src/main/java/cn/nukkit/block/BlockEnderChest.java
@@ -186,4 +186,9 @@ public class BlockEnderChest extends BlockTransparent implements Faceable {
     public BlockFace getBlockFace() {
         return BlockFace.fromHorizontalIndex(this.getDamage() & 0x07);
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockFence.java
+++ b/src/main/java/cn/nukkit/block/BlockFence.java
@@ -61,4 +61,9 @@ public abstract class BlockFence extends BlockTransparent {
     public Item toItem() {
         return Item.get(id, this.getDamage());
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockFenceGate.java
+++ b/src/main/java/cn/nukkit/block/BlockFenceGate.java
@@ -186,4 +186,9 @@ public class BlockFenceGate extends BlockTransparent implements Faceable {
     public BlockFace getBlockFace() {
         return BlockFace.fromHorizontalIndex(this.getDamage() & 0x07);
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockFlowerPot.java
+++ b/src/main/java/cn/nukkit/block/BlockFlowerPot.java
@@ -166,4 +166,9 @@ public class BlockFlowerPot extends FloodableBlock {
     public Item toItem() {
         return Item.get(ItemIds.FLOWER_POT);
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockGlassPane.java
+++ b/src/main/java/cn/nukkit/block/BlockGlassPane.java
@@ -38,4 +38,9 @@ public class BlockGlassPane extends BlockThin {
     public boolean canSilkTouch() {
         return true;
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockHopper.java
+++ b/src/main/java/cn/nukkit/block/BlockHopper.java
@@ -152,4 +152,9 @@ public class BlockHopper extends BlockTransparent implements Faceable {
     public BlockFace getBlockFace() {
         return BlockFace.fromHorizontalIndex(this.getDamage() & 0x07);
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockIronBars.java
+++ b/src/main/java/cn/nukkit/block/BlockIronBars.java
@@ -55,4 +55,9 @@ public class BlockIronBars extends BlockThin {
     public boolean canHarvestWithHand() {
         return false;
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockItemFrame.java
+++ b/src/main/java/cn/nukkit/block/BlockItemFrame.java
@@ -107,7 +107,7 @@ public class BlockItemFrame extends BlockTransparent {
 
     @Override
     public boolean onBreak(Item item) {
-        this.getLevel().setBlock(this, Block.get(AIR), true, true);
+        super.onBreak(item);
         this.getLevel().addSound(this.asVector3f(), Sound.BLOCK_ITEMFRAME_REMOVE_ITEM);
         return true;
     }

--- a/src/main/java/cn/nukkit/block/BlockItemFrame.java
+++ b/src/main/java/cn/nukkit/block/BlockItemFrame.java
@@ -173,4 +173,9 @@ public class BlockItemFrame extends BlockTransparent {
     public double getHardness() {
         return 0.25;
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockLadder.java
+++ b/src/main/java/cn/nukkit/block/BlockLadder.java
@@ -174,4 +174,9 @@ public class BlockLadder extends BlockTransparent implements Faceable {
     public BlockFace getBlockFace() {
         return BlockFace.fromHorizontalIndex(this.getDamage() & 0x07);
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockLava.java
+++ b/src/main/java/cn/nukkit/block/BlockLava.java
@@ -160,7 +160,8 @@ public class BlockLava extends BlockLiquid {
         Block colliding = null;
         for(int side = 1; side < 6; ++side){ //don't check downwards side
             Block blockSide = this.getSide(BlockFace.fromIndex(side));
-            if(blockSide instanceof BlockWater){
+            if(blockSide instanceof BlockWater
+                    || (blockSide = blockSide.getBlockAtLayer(1)) instanceof BlockWater){
                 colliding = blockSide;
                 break;
             }

--- a/src/main/java/cn/nukkit/block/BlockLava.java
+++ b/src/main/java/cn/nukkit/block/BlockLava.java
@@ -139,7 +139,7 @@ public class BlockLava extends BlockLiquid {
 
     @Override
     public Block getBlock(int meta) {
-        return Block.get(LAVA, meta);
+        return Block.get(FLOWING_LAVA, meta);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockLeaves.java
+++ b/src/main/java/cn/nukkit/block/BlockLeaves.java
@@ -164,4 +164,9 @@ public class BlockLeaves extends BlockTransparent {
     protected Item getSapling() {
         return Item.get(SAPLING, this.getDamage() & 0x03);
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockLever.java
+++ b/src/main/java/cn/nukkit/block/BlockLever.java
@@ -90,7 +90,7 @@ public class BlockLever extends FloodableBlock implements Faceable {
 
     @Override
     public boolean onBreak(Item item) {
-        this.getLevel().setBlock(this, Block.get(AIR), true, true);
+        super.onBreak(item);
 
         if (isPowerOn()) {
             BlockFace face = LeverOrientation.byMetadata(this.isPowerOn() ? this.getDamage() ^ 0x08 : this.getDamage()).getFacing();

--- a/src/main/java/cn/nukkit/block/BlockLever.java
+++ b/src/main/java/cn/nukkit/block/BlockLever.java
@@ -217,4 +217,14 @@ public class BlockLever extends FloodableBlock implements Faceable {
     public BlockColor getColor() {
         return BlockColor.AIR_BLOCK_COLOR;
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
+
+    @Override
+    public boolean canWaterlogFlowing() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockLiquid.java
+++ b/src/main/java/cn/nukkit/block/BlockLiquid.java
@@ -188,8 +188,18 @@ public abstract class BlockLiquid extends BlockTransparent {
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_NORMAL) {
             this.checkForHarden();
+            if (usesWaterLogging() && layer > 0) {
+                Block mainBlock = this.level.getBlock(layer(0));
+                if (mainBlock.getId() == AIR) {
+                    this.level.setBlock(layer(1), mainBlock, false, false);
+                    this.level.setBlock(layer(0), this, false, false);
+                } else if (!mainBlock.canWaterlog() /*|| TODO: flowing-waterlogging support mainBlock.getWaterloggingLevel() == 1 && getDamage() > 0*/) {
+                    this.level.setBlock(layer(1), Block.get(AIR), true, true);
+                    return type;
+                }
+            }
             this.level.scheduleUpdate(this, this.tickRate());
-            return 0;
+            return type;
         } else if (type == Level.BLOCK_UPDATE_SCHEDULED) {
             int decay = this.getFlowDecay(this);
             int multiplier = this.getFlowDecayPerBlock();
@@ -263,6 +273,7 @@ public abstract class BlockLiquid extends BlockTransparent {
                 }
                 this.checkForHarden();
             }
+            return type;
         }
         return 0;
     }
@@ -453,5 +464,9 @@ public abstract class BlockLiquid extends BlockTransparent {
     @Override
     public Item toItem() {
         return Item.get(AIR, 0, 0);
+    }
+
+    public boolean usesWaterLogging() {
+        return false;
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockLiquid.java
+++ b/src/main/java/cn/nukkit/block/BlockLiquid.java
@@ -188,11 +188,12 @@ public abstract class BlockLiquid extends BlockTransparent {
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_NORMAL) {
             this.checkForHarden();
+            // This check exists because if water is at layer1 with air at layer0, the water gets invisible
             if (usesWaterLogging() && layer > 0) {
                 Block mainBlock = this.level.getBlock(layer(0));
                 if (mainBlock.getId() == AIR) {
-                    this.level.setBlock(layer(1), mainBlock, false, false);
-                    this.level.setBlock(layer(0), this, false, false);
+                    this.level.setBlock(layer(1), mainBlock, true, false);
+                    this.level.setBlock(layer(0), this, true, false);
                 } else if (!mainBlock.canWaterlogSource() || !mainBlock.canWaterlogFlowing() && getDamage() > 0) {
                     this.level.setBlock(layer(1), Block.get(AIR), true, true);
                     return type;

--- a/src/main/java/cn/nukkit/block/BlockLiquid.java
+++ b/src/main/java/cn/nukkit/block/BlockLiquid.java
@@ -193,7 +193,7 @@ public abstract class BlockLiquid extends BlockTransparent {
                 if (mainBlock.getId() == AIR) {
                     this.level.setBlock(layer(1), mainBlock, false, false);
                     this.level.setBlock(layer(0), this, false, false);
-                } else if (!mainBlock.canWaterlog() /*|| TODO: flowing-waterlogging support mainBlock.getWaterloggingLevel() == 1 && getDamage() > 0*/) {
+                } else if (!mainBlock.canWaterlogSource() || !mainBlock.canWaterlogFlowing() && getDamage() > 0) {
                     this.level.setBlock(layer(1), Block.get(AIR), true, true);
                     return type;
                 }

--- a/src/main/java/cn/nukkit/block/BlockMobSpawner.java
+++ b/src/main/java/cn/nukkit/block/BlockMobSpawner.java
@@ -43,4 +43,8 @@ public class BlockMobSpawner extends BlockSolid {
         return false;
     }
 
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockPistonBase.java
+++ b/src/main/java/cn/nukkit/block/BlockPistonBase.java
@@ -74,7 +74,7 @@ public abstract class BlockPistonBase extends BlockSolid implements Faceable {
 
     @Override
     public boolean onBreak(Item item) {
-        this.level.setBlock(this, Block.get(AIR), true, true);
+        super.onBreak(item);
 
         Block block = this.getSide(getFacing());
 

--- a/src/main/java/cn/nukkit/block/BlockPistonBase.java
+++ b/src/main/java/cn/nukkit/block/BlockPistonBase.java
@@ -403,4 +403,9 @@ public abstract class BlockPistonBase extends BlockSolid implements Faceable {
     public BlockFace getBlockFace() {
         return BlockFace.fromHorizontalIndex(this.getDamage() & 0x07);
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockPistonHead.java
+++ b/src/main/java/cn/nukkit/block/BlockPistonHead.java
@@ -54,4 +54,9 @@ public class BlockPistonHead extends BlockTransparent {
     public Item toItem() {
         return Item.get(AIR, 0, 0);
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockPistonHead.java
+++ b/src/main/java/cn/nukkit/block/BlockPistonHead.java
@@ -32,7 +32,7 @@ public class BlockPistonHead extends BlockTransparent {
 
     @Override
     public boolean onBreak(Item item) {
-        this.level.setBlock(this, Block.get(AIR), true, true);
+        super.onBreak(item);
         Block piston = getSide(getFacing().getOpposite());
 
         if (piston instanceof BlockPistonBase && ((BlockPistonBase) piston).getFacing() == this.getFacing()) {

--- a/src/main/java/cn/nukkit/block/BlockPressurePlateBase.java
+++ b/src/main/java/cn/nukkit/block/BlockPressurePlateBase.java
@@ -203,4 +203,9 @@ public abstract class BlockPressurePlateBase extends FloodableBlock {
     public Item toItem() {
         return Item.get(AIR, 0, 0);
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockPressurePlateBase.java
+++ b/src/main/java/cn/nukkit/block/BlockPressurePlateBase.java
@@ -161,7 +161,7 @@ public abstract class BlockPressurePlateBase extends FloodableBlock {
 
     @Override
     public boolean onBreak(Item item) {
-        this.level.setBlock(this, Block.get(AIR), true, true);
+        super.onBreak(item);
 
         if (this.getRedstonePower() > 0) {
             this.level.updateAroundRedstone(this, null);

--- a/src/main/java/cn/nukkit/block/BlockRedstoneDiode.java
+++ b/src/main/java/cn/nukkit/block/BlockRedstoneDiode.java
@@ -209,4 +209,14 @@ public abstract class BlockRedstoneDiode extends FloodableBlock implements Facea
     public BlockColor getColor() {
         return BlockColor.AIR_BLOCK_COLOR;
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
+
+    @Override
+    public boolean canWaterlogFlowing() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockRedstoneDiode.java
+++ b/src/main/java/cn/nukkit/block/BlockRedstoneDiode.java
@@ -27,7 +27,7 @@ public abstract class BlockRedstoneDiode extends FloodableBlock implements Facea
     @Override
     public boolean onBreak(Item item) {
         Vector3i pos = asVector3i();
-        this.level.setBlock(this, Block.get(AIR), true, true);
+        super.onBreak(item);
 
         for (BlockFace face : BlockFace.values()) {
             this.level.updateAroundRedstone(pos.getSide(face), null);

--- a/src/main/java/cn/nukkit/block/BlockSignPost.java
+++ b/src/main/java/cn/nukkit/block/BlockSignPost.java
@@ -117,4 +117,9 @@ public class BlockSignPost extends BlockTransparent implements Faceable {
     public BlockFace getBlockFace() {
         return BlockFace.fromIndex(this.getDamage() & 0x07);
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockSkull.java
+++ b/src/main/java/cn/nukkit/block/BlockSkull.java
@@ -104,4 +104,9 @@ public class BlockSkull extends BlockTransparent {
     public BlockColor getColor() {
         return BlockColor.AIR_BLOCK_COLOR;
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockSlab.java
+++ b/src/main/java/cn/nukkit/block/BlockSlab.java
@@ -88,4 +88,9 @@ public abstract class BlockSlab extends BlockTransparent {
     }
 
     protected abstract Identifier getDoubleSlab();
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockStairs.java
+++ b/src/main/java/cn/nukkit/block/BlockStairs.java
@@ -142,4 +142,9 @@ public abstract class BlockStairs extends BlockTransparent implements Faceable {
     public BlockFace getBlockFace() {
         return BlockFace.fromHorizontalIndex(this.getDamage() & 0x7);
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockTrapdoor.java
+++ b/src/main/java/cn/nukkit/block/BlockTrapdoor.java
@@ -246,4 +246,9 @@ public class BlockTrapdoor extends BlockTransparent implements Faceable {
     public static BlockFactory factory(BlockColor blockColor) {
         return identifier -> new BlockTrapdoor(identifier, blockColor);
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockTripWire.java
+++ b/src/main/java/cn/nukkit/block/BlockTripWire.java
@@ -163,10 +163,10 @@ public class BlockTripWire extends FloodableBlock {
             this.setDisarmed(true);
             this.level.setBlock(this, this, true, false);
             this.updateHook(false);
-            this.getLevel().setBlock(this, Block.get(AIR), true, true);
+            super.onBreak(item);
         } else {
             this.setPowered(true);
-            this.getLevel().setBlock(this, Block.get(AIR), true, true);
+            super.onBreak(item);
             this.updateHook(true);
         }
 

--- a/src/main/java/cn/nukkit/block/BlockTripWire.java
+++ b/src/main/java/cn/nukkit/block/BlockTripWire.java
@@ -182,4 +182,14 @@ public class BlockTripWire extends FloodableBlock {
     protected AxisAlignedBB recalculateCollisionBoundingBox() {
         return this;
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
+
+    @Override
+    public boolean canWaterlogFlowing() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockTripWireHook.java
+++ b/src/main/java/cn/nukkit/block/BlockTripWireHook.java
@@ -223,4 +223,14 @@ public class BlockTripWireHook extends FloodableBlock {
     public Item toItem() {
         return Item.get(id, 0);
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
+
+    @Override
+    public boolean canWaterlogFlowing() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockUndyedShulkerBox.java
+++ b/src/main/java/cn/nukkit/block/BlockUndyedShulkerBox.java
@@ -143,4 +143,9 @@ public class BlockUndyedShulkerBox extends BlockTransparent {
     public BlockColor getColor() {
         return BlockColor.PURPLE_BLOCK_COLOR;
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockVine.java
+++ b/src/main/java/cn/nukkit/block/BlockVine.java
@@ -195,4 +195,9 @@ public class BlockVine extends BlockTransparent {
     public BlockColor getColor() {
         return BlockColor.FOLIAGE_BLOCK_COLOR;
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockWall.java
+++ b/src/main/java/cn/nukkit/block/BlockWall.java
@@ -80,4 +80,9 @@ public class BlockWall extends BlockTransparent {
     public boolean canHarvestWithHand() {
         return false;
     }
+
+    @Override
+    public boolean canWaterlogSource() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/block/BlockWater.java
+++ b/src/main/java/cn/nukkit/block/BlockWater.java
@@ -51,4 +51,9 @@ public class BlockWater extends BlockLiquid {
     public int tickRate() {
         return 5;
     }
+
+    @Override
+    public boolean usesWaterLogging() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityCauldron.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityCauldron.java
@@ -29,7 +29,7 @@ public class BlockEntityCauldron extends BlockEntitySpawnable {
     }
 
     public int getPotionId() {
-        return namedTag.getShort("PotionId");
+        return namedTag.getShort("PotionId") & 0xffff;
     }
 
     public void setPotionId(int potionId) {

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityCauldron.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityCauldron.java
@@ -29,7 +29,7 @@ public class BlockEntityCauldron extends BlockEntitySpawnable {
     }
 
     public int getPotionId() {
-        return namedTag.getShort("PotionId") & 0xffff;
+        return namedTag.getShort("PotionId");
     }
 
     public void setPotionId(int potionId) {

--- a/src/main/java/cn/nukkit/entity/impl/BaseEntity.java
+++ b/src/main/java/cn/nukkit/entity/impl/BaseEntity.java
@@ -1656,6 +1656,10 @@ public abstract class BaseEntity extends Location implements Entity, Metadatable
                 if (b.collidesWithBB(this.getBoundingBox(), true)) {
                     this.collisionBlocks.add(b);
                 }
+                Block layer1 = b.getBlockAtLayer(1);
+                if (layer1.collidesWithBB(this.getBoundingBox(), true)) {
+                    this.collisionBlocks.add(layer1);
+                }
             }
         }
 

--- a/src/main/java/cn/nukkit/item/ItemBucket.java
+++ b/src/main/java/cn/nukkit/item/ItemBucket.java
@@ -135,11 +135,11 @@ public class ItemBucket extends Item {
         } else if (bucketContents instanceof BlockLiquid) {
             Item result = Item.get(BUCKET, 0, 1);
             Block emptyTarget = block;
-            if (target.canWaterlog() && bucketContents.getId() == FLOWING_WATER) {
+            if (target.canWaterlogSource() && bucketContents.getId() == FLOWING_WATER) {
                 emptyTarget = target;
             }
             PlayerBucketEmptyEvent ev = new PlayerBucketEmptyEvent(player, emptyTarget, face, this, result);
-            if (!emptyTarget.canBeFlooded() && !emptyTarget.canWaterlog()) {
+            if (!emptyTarget.canBeFlooded() && !emptyTarget.canWaterlogSource()) {
                 ev.setCancelled(true);
             }
 
@@ -151,7 +151,7 @@ public class ItemBucket extends Item {
 
             if (!ev.isCancelled()) {
                 BlockPosition pos = BlockPosition.from(emptyTarget);
-                if (emptyTarget.canWaterlog()) {
+                if (emptyTarget.canWaterlogSource()) {
                     pos.setLayer(1);
                 }
                 target.getLevel().setBlock(pos, bucketContents, false, false);

--- a/src/main/java/cn/nukkit/item/ItemBucket.java
+++ b/src/main/java/cn/nukkit/item/ItemBucket.java
@@ -154,7 +154,7 @@ public class ItemBucket extends Item {
                 if (emptyTarget.canWaterlogSource()) {
                     pos.setLayer(1);
                 }
-                target.getLevel().setBlock(pos, bucketContents, false, false);
+                target.getLevel().setBlock(pos, bucketContents, false, true);
                 bucketContents.getLevel().scheduleUpdate(bucketContents, bucketContents.tickRate());
                 if (player.isSurvival()) {
                     Item clone = this.clone();

--- a/src/main/java/cn/nukkit/item/ItemBucket.java
+++ b/src/main/java/cn/nukkit/item/ItemBucket.java
@@ -154,7 +154,7 @@ public class ItemBucket extends Item {
                 if (emptyTarget.canWaterlogSource()) {
                     pos.setLayer(1);
                 }
-                target.getLevel().setBlock(pos, bucketContents, false, true);
+                target.getLevel().setBlock(pos, bucketContents, true, true);
                 bucketContents.getLevel().scheduleUpdate(bucketContents, bucketContents.tickRate());
                 if (player.isSurvival()) {
                     Item clone = this.clone();

--- a/src/main/java/cn/nukkit/level/BlockPosition.java
+++ b/src/main/java/cn/nukkit/level/BlockPosition.java
@@ -211,6 +211,10 @@ public class BlockPosition extends Vector3i {
         return getSide(BlockFace.WEST, step);
     }
 
+    public BlockPosition layer(int layer) {
+        return new BlockPosition(this.x, this.y, this.z, this.level, layer);
+    }
+
     public Level getLevel() {
         return level;
     }
@@ -231,6 +235,11 @@ public class BlockPosition extends Vector3i {
 
     public Block getBlock() {
         if (this.isValid()) return this.level.getBlock(this);
+        else throw new LevelException("Undefined Level reference");
+    }
+
+    public Block getBlockAtLayer(int layer) {
+        if (this.isValid()) return this.level.getBlock(this.x, this.y, this.z, layer);
         else throw new LevelException("Undefined Level reference");
     }
 

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -3,6 +3,7 @@ package cn.nukkit.level;
 import cn.nukkit.Server;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockIds;
+import cn.nukkit.block.BlockLiquid;
 import cn.nukkit.block.BlockRedstoneDiode;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.entity.Entity;
@@ -1928,8 +1929,34 @@ public class Level implements ChunkManager, Metadatable {
             }
         }
 
-        if (!hand.place(item, block, target, face, clickPos, player)) {
-            return null;
+        Block liquid = block;
+        Block air = block.getBlockAtLayer(1);
+        BlockPosition layer0 = null;
+        BlockPosition layer1 = null;
+        if (air.getId() == BlockIds.AIR && (liquid instanceof BlockLiquid) && ((BlockLiquid) liquid).usesWaterLogging()) {
+            layer0 = liquid.layer(0);
+            layer1 = air.layer(1);
+
+            this.setBlock(layer1, liquid, false, false);
+            this.setBlock(layer0, air, false, false);
+            block = air;
+            this.scheduleUpdate(block, 1);
+        }
+
+        try {
+            if (!hand.place(item, block, target, face, clickPos, player)) {
+                if (layer0 != null) {
+                    this.setBlock(layer0, block, false, false);
+                    this.setBlock(layer1, Block.get(BlockIds.AIR), false, false);
+                }
+                return null;
+            }
+        } catch (Exception e) {
+            if (layer0 != null) {
+                this.setBlock(layer0, block, false, false);
+                this.setBlock(layer1, Block.get(BlockIds.AIR), false, false);
+            }
+            throw e;
         }
 
         if (player != null) {

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -1933,7 +1933,9 @@ public class Level implements ChunkManager, Metadatable {
         Block air = block.getBlockAtLayer(1);
         BlockPosition layer0 = null;
         BlockPosition layer1 = null;
-        if (air.getId() == BlockIds.AIR && (liquid instanceof BlockLiquid) && ((BlockLiquid) liquid).usesWaterLogging()) {
+        if (air.getId() == BlockIds.AIR && (liquid instanceof BlockLiquid) && ((BlockLiquid) liquid).usesWaterLogging()
+                && (liquid.getDamage() == 0 || liquid.getDamage() == 8) // Remove this line when MCPE-33345 is resolved
+        ) {
             layer0 = liquid.layer(0);
             layer1 = air.layer(1);
 

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -1946,15 +1946,15 @@ public class Level implements ChunkManager, Metadatable {
         try {
             if (!hand.place(item, block, target, face, clickPos, player)) {
                 if (layer0 != null) {
-                    this.setBlock(layer0, block, false, false);
-                    this.setBlock(layer1, Block.get(BlockIds.AIR), false, false);
+                    this.setBlock(layer0, liquid, false, false);
+                    this.setBlock(layer1, air, false, false);
                 }
                 return null;
             }
         } catch (Exception e) {
             if (layer0 != null) {
-                this.setBlock(layer0, block, false, false);
-                this.setBlock(layer1, Block.get(BlockIds.AIR), false, false);
+                this.setBlock(layer0, liquid, false, false);
+                this.setBlock(layer1, air, false, false);
             }
             throw e;
         }


### PR DESCRIPTION
- [x] Add waterlogging properties to all waterloggable blocks
- [x] Makes the waterlogging functionality more generic
- [x] Adds some utility methods for handling the block layers.
- [x] Optimizes the campfire onUpdate implementation.
- [x] Fixes bug when placing a waterloggable block in water
- [x] Moves water from layer 1 to layer 0 when the main block is removed
- [x] Adds support for flowing-waterlogging
- [x] Make sure doors are waterlogging correctly
- [x] Make sure beds are waterlogging correctly
- [x] ~~Make sure cauldrons gets filled with water when waterlogged~~ (will be fixed in an other branch, cauldron is not really waterloggable)
- [x] Review and test the waterlogging properties on every waterloggable block
- [x] Fix: Water stream blinks when a waterlogged block is removed
- [x] Detect collision between lava and water across different layers
- [x] Lava taking too long to become obsidian when placed right next to a water block
- [x] Fix: Lava not flowing more than one block
- [x] Fix: Waterlogged water not extinguishing entities on fire

**Important**: I made two necessary breaking changes in this PR to the new waterlogging system, since 2.0 this is alpha and these methods are new, these shouldn't cause much problems:
1. `Block.onWaterlog()` was removed because this should be done in the `onUpdate` logic for block updates, some waterlogged blocks needs to know when it is waterlogged by a full water, lower level water or when it looses waterlogging, all this can be done in `onUpdate` and `onWaterlog` was dealing only with possible case.
2. `BlockCampfire.onWaterlog` removed as described above and it's logic were already implemented in `onUpdate`, I just optimized it and fixed a potential lag issue.
3. `Block.canWaterlog()` was renamed to `Block.canWaterlogSource()`, I did that to avoid confusion because as in https://minecraft.gamepedia.com/Waterlogging#Behavior there are three kinds of waterlogging behaviour: 1> No waterlogging at all; 2> Only source; 3> Source and flowing. This change allowed me to add `Block.canWaterlogFlowing()` and have a good distinction between both by it's name.

Reference: GameModsBr#182