### PR TITLE
[2.0] Fix a startup error

### DIFF
--- a/src/main/java/cn/nukkit/level/LevelData.java
+++ b/src/main/java/cn/nukkit/level/LevelData.java
@@ -23,7 +23,7 @@ public class LevelData {
     private long randomSeed = ThreadLocalRandom.current().nextLong();
     private int dimension;
     private Identifier generator;
-    private String generatorOptions;
+    private String generatorOptions = "";
     private String name = "World";
     private long time;
     private Vector3i spawn = new Vector3i(0, 128, 0);
@@ -129,7 +129,11 @@ public class LevelData {
     }
 
     public void setGeneratorOptions(String generatorOptions) {
-        this.generatorOptions = generatorOptions;
+        if (generatorOptions == null) {
+            this.generatorOptions = "";
+        } else {
+            this.generatorOptions = generatorOptions;
+        }
     }
 
     public String getName() {

--- a/src/main/java/cn/nukkit/nbt/tag/StringTag.java
+++ b/src/main/java/cn/nukkit/nbt/tag/StringTag.java
@@ -15,7 +15,7 @@ public class StringTag extends Tag {
     public StringTag(String name, String data) {
         super(name);
         this.data = data;
-        if (data == null) throw new IllegalArgumentException("Empty string not allowed");
+        if (data == null) throw new IllegalArgumentException("Null string not allowed");
     }
 
     @Override


### PR DESCRIPTION
Related to #1171, #1092 and NukkitX/Languages#32

Fixes:
```java
Caused by: java.lang.IllegalArgumentException: Empty string not allowed
    at cn.nukkit.nbt.tag.StringTag.<init>(StringTag.java:18) ~[classes/:?]
    at cn.nukkit.nbt.tag.CompoundTag.putString(CompoundTag.java:97) ~[classes/:?]
    at cn.nukkit.level.provider.leveldb.serializer.LevelDBDataSerializer.saveData(LevelDBDataSerializer.java:68) ~[classes/:?]
```
when starting a clean server.

To actually start the server it's also needed to manually configure the worlds in `nukkit.yml` as in:
https://github.com/NukkitX/Languages/pull/32/files for now.