### PR TITLE
[2.0] Fix two critical packet issues

### DIFF
--- a/src/main/java/cn/nukkit/network/RakNetInterface.java
+++ b/src/main/java/cn/nukkit/network/RakNetInterface.java
@@ -179,9 +179,10 @@ public class RakNetInterface implements RakNetServerListener, AdvancedSourceInte
             }
             return null;
         }
-        ByteBuf byteBuf = ByteBufAllocator.DEFAULT.ioBuffer(1 + buffer.readableBytes());
+        int readableBytes = buffer.readableBytes();
+        ByteBuf byteBuf = ByteBufAllocator.DEFAULT.ioBuffer(1 + readableBytes);
         byteBuf.writeByte(0xfe);
-        byteBuf.writeBytes(buffer);
+        byteBuf.writeBytes(buffer, 0, readableBytes);
 
         session.send(byteBuf, immediate ? RakNetPriority.IMMEDIATE : RakNetPriority.MEDIUM,
                 RakNetReliability.RELIABLE_ORDERED, 0);

--- a/src/main/java/cn/nukkit/registry/ItemRegistry.java
+++ b/src/main/java/cn/nukkit/registry/ItemRegistry.java
@@ -45,7 +45,7 @@ public class ItemRegistry implements Registry {
     private final BiMap<Integer, Identifier> runtimeIdMap = HashBiMap.create();
     private final AtomicInteger runtimeIdAllocator = new AtomicInteger(VANILLA_ITEMS.size());
     private final BlockRegistry blockRegistry;
-    private ByteBuf cachedRuntimeItems;
+    private byte[] cachedRuntimeItems;
     private volatile boolean closed;
 
     private ItemRegistry(BlockRegistry blockRegistry) {
@@ -165,7 +165,9 @@ public class ItemRegistry implements Registry {
             Binary.writeString(buffer, blockId.toString());
             buffer.writeShortLE(this.getRuntimeId(blockId));
         }
-        this.cachedRuntimeItems = buffer;
+
+        this.cachedRuntimeItems = new byte[buffer.readableBytes()];
+        buffer.readBytes(this.cachedRuntimeItems);
     }
 
     private void checkClosed() throws RegistryException {
@@ -174,7 +176,7 @@ public class ItemRegistry implements Registry {
         }
     }
 
-    public ByteBuf getCachedRuntimeItems() {
+    public byte[] getCachedRuntimeItems() {
         return cachedRuntimeItems;
     }
 


### PR DESCRIPTION
These issues were discovered using ProxyPass when I was trying to test the server with two players. The client game were hanging and crashing both on Windows 10 and Android randomly when two or more players were online.

1. The `StartGamePacket` was being sent correctly only to the first player who joins the server, the next players (including the first player if he reconnects) were receiving a packet without any item registered because the `ItemRegistry`'s `ByteBuf` cache were having it's `readIndex()` changed. I changed it to `byte[]`, same as `BlockRegistry`, for safety because the getter is public and other plugins could easily read it changing the `readIndex` again.
2. When two or more players would receive the same packet (`BatchPacketsEvent` being called with two+ players in the array), only the first player would receive valid packets, the other players would receive corrupt packets because the `BatchPacket.payload`'s `readIndex` were being changed, so I made the `RakNetInterface` read that buffer without changing the `readIndex`. 

![image](https://user-images.githubusercontent.com/3679022/74204104-99d21c80-4c50-11ea-9764-2305aad950c2.png)

The errors can be seen having two players connected through ProxyPass and have one of them jumping, or just waiting the `SetTimePacket` attempt to be sent to all players.

Reference: GameModsBr#189