### PR TITLE
[2.0] Fixes wrong Stripped Log Block damage

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockStrippedLog.java
+++ b/src/main/java/cn/nukkit/block/BlockStrippedLog.java
@@ -1,5 +1,9 @@
 package cn.nukkit.block;
 
+import cn.nukkit.item.Item;
+import cn.nukkit.math.BlockFace;
+import cn.nukkit.math.Vector3f;
+import cn.nukkit.player.Player;
 import cn.nukkit.utils.Identifier;
 
 public class BlockStrippedLog extends BlockLog {
@@ -11,5 +15,11 @@ public class BlockStrippedLog extends BlockLog {
     @Override
     public boolean canBeActivated() {
         return false;
+    }
+
+    @Override
+    public boolean place(Item item, Block block, Block target, BlockFace face, Vector3f clickPos, Player player) {
+        this.setDamage(FACES[face.getIndex()] >> 2);
+        return this.getLevel().setBlock(this.asVector3i(), this, true, true);
     }
 }


### PR DESCRIPTION
The block missed a `place` override, so the data were 2 bits shifted to the left.

Reference: GameModsBr#190