### PR TITLE
[2.0] Fix explosion behaviour with waterlogged blocks and some other bugs

### DIFF
--- a/src/main/java/cn/nukkit/entity/impl/BaseEntity.java
+++ b/src/main/java/cn/nukkit/entity/impl/BaseEntity.java
@@ -1426,7 +1426,7 @@ public abstract class BaseEntity extends Location implements Entity, Metadatable
         Block block = this.level.getLoadedBlock(NukkitMath.floorDouble(this.x), NukkitMath.floorDouble(y),
                 NukkitMath.floorDouble(this.z));
 
-        if (block instanceof BlockWater) {
+        if (block instanceof BlockWater || (block = block != null? block.getBlockAtLayer(1): null) instanceof BlockWater) {
             double f = (block.y + 1) - (((BlockWater) block).getFluidHeightPercent() - 0.1111111);
             return y < f;
         }

--- a/src/main/java/cn/nukkit/entity/impl/misc/EntityDroppedItem.java
+++ b/src/main/java/cn/nukkit/entity/impl/misc/EntityDroppedItem.java
@@ -10,6 +10,7 @@ import cn.nukkit.event.entity.EntityDamageEvent.DamageCause;
 import cn.nukkit.event.entity.ItemDespawnEvent;
 import cn.nukkit.event.entity.ItemSpawnEvent;
 import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemIds;
 import cn.nukkit.level.chunk.Chunk;
 import cn.nukkit.nbt.NBTIO;
 import cn.nukkit.nbt.tag.CompoundTag;
@@ -115,7 +116,7 @@ public class EntityDroppedItem extends BaseEntity implements DroppedItem {
                 (source.getCause() == DamageCause.ENTITY_EXPLOSION ||
                 source.getCause() == DamageCause.BLOCK_EXPLOSION) &&
                 !this.isInsideOfWater() && (this.item == null ||
-                this.item.getId() != Item.NETHER_STAR)) && super.attack(source);
+                this.item.getId() != ItemIds.NETHER_STAR)) && super.attack(source);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/impl/misc/EntityDroppedItem.java
+++ b/src/main/java/cn/nukkit/entity/impl/misc/EntityDroppedItem.java
@@ -110,10 +110,12 @@ public class EntityDroppedItem extends BaseEntity implements DroppedItem {
     @Override
     public boolean attack(EntityDamageEvent source) {
         return (source.getCause() == DamageCause.VOID ||
+                source.getCause() == DamageCause.CONTACT ||
                 source.getCause() == DamageCause.FIRE_TICK ||
-                source.getCause() == DamageCause.ENTITY_EXPLOSION ||
-                source.getCause() == DamageCause.BLOCK_EXPLOSION)
-                && super.attack(source);
+                (source.getCause() == DamageCause.ENTITY_EXPLOSION ||
+                source.getCause() == DamageCause.BLOCK_EXPLOSION) &&
+                !this.isInsideOfWater() && (this.item == null ||
+                this.item.getId() != Item.NETHER_STAR)) && super.attack(source);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/impl/misc/EntityXpOrb.java
+++ b/src/main/java/cn/nukkit/entity/impl/misc/EntityXpOrb.java
@@ -90,9 +90,9 @@ public class EntityXpOrb extends BaseEntity implements XpOrb {
     public boolean attack(EntityDamageEvent source) {
         return (source.getCause() == DamageCause.VOID ||
                 source.getCause() == DamageCause.FIRE_TICK ||
-                source.getCause() == DamageCause.ENTITY_EXPLOSION ||
-                source.getCause() == DamageCause.BLOCK_EXPLOSION)
-                && super.attack(source);
+                (source.getCause() == DamageCause.ENTITY_EXPLOSION ||
+                source.getCause() == DamageCause.BLOCK_EXPLOSION) &&
+                !this.isInsideOfWater()) && super.attack(source);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/item/ItemBucket.java
+++ b/src/main/java/cn/nukkit/item/ItemBucket.java
@@ -154,8 +154,9 @@ public class ItemBucket extends Item {
                 if (emptyTarget.canWaterlogSource()) {
                     pos.setLayer(1);
                 }
-                target.getLevel().setBlock(pos, bucketContents, true, true);
-                bucketContents.getLevel().scheduleUpdate(bucketContents, bucketContents.tickRate());
+                if (target.getLevel().setBlock(pos, bucketContents, true, true)) {
+                    bucketContents.getLevel().scheduleUpdate(bucketContents, bucketContents.tickRate());
+                }
                 if (player.isSurvival()) {
                     Item clone = this.clone();
                     clone.setCount(this.getCount() - 1);

--- a/src/main/java/cn/nukkit/level/Explosion.java
+++ b/src/main/java/cn/nukkit/level/Explosion.java
@@ -3,8 +3,8 @@ package cn.nukkit.level;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockTNT;
 import cn.nukkit.entity.Entity;
-import cn.nukkit.entity.item.EntityItem;
-import cn.nukkit.entity.item.EntityXPOrb;
+import cn.nukkit.entity.misc.DroppedItem;
+import cn.nukkit.entity.misc.XpOrb;
 import cn.nukkit.event.block.BlockUpdateEvent;
 import cn.nukkit.event.entity.EntityDamageByBlockEvent;
 import cn.nukkit.event.entity.EntityDamageByEntityEvent;
@@ -163,7 +163,7 @@ public class Explosion {
                     entity.attack(new EntityDamageEvent(entity, DamageCause.BLOCK_EXPLOSION, damage));
                 }
 
-                if (!(entity instanceof EntityItem || entity instanceof EntityXPOrb)) {
+                if (!(entity instanceof DroppedItem || entity instanceof XpOrb)) {
                     entity.setMotion(motion.multiply(impact));
                 }
             }

--- a/src/main/java/cn/nukkit/level/Explosion.java
+++ b/src/main/java/cn/nukkit/level/Explosion.java
@@ -3,6 +3,8 @@ package cn.nukkit.level;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockTNT;
 import cn.nukkit.entity.Entity;
+import cn.nukkit.entity.item.EntityItem;
+import cn.nukkit.entity.item.EntityXPOrb;
 import cn.nukkit.event.block.BlockUpdateEvent;
 import cn.nukkit.event.entity.EntityDamageByBlockEvent;
 import cn.nukkit.event.entity.EntityDamageByEntityEvent;
@@ -161,7 +163,9 @@ public class Explosion {
                     entity.attack(new EntityDamageEvent(entity, DamageCause.BLOCK_EXPLOSION, damage));
                 }
 
-                entity.setMotion(motion.multiply(impact));
+                if (!(entity instanceof EntityItem || entity instanceof EntityXPOrb)) {
+                    entity.setMotion(motion.multiply(impact));
+                }
             }
         }
 

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -1847,10 +1847,6 @@ public class Level implements ChunkManager, Metadatable {
                 }
                 return null;
             }
-
-            if (item.getId() == ItemIds.BUCKET && ItemBucket.getBlockIdFromDamage(item.getDamage()) == FLOWING_WATER) {
-                player.getLevel().sendBlocks(new Player[]{player}, new Block[]{Block.get(AIR, 0, target.setLayer(1))}, UpdateBlockPacket.FLAG_ALL_PRIORITY);
-            }
         } else if (target.canBeActivated() && target.onActivate(item, player)) {
             if (item.isTool() && item.getDamage() >= item.getMaxDurability()) {
                 item = Item.get(BlockIds.AIR, 0, 0);


### PR DESCRIPTION
This fixes:

- [x] Explosion damaging drops in the water (port of NukkitX#1184 to `2.0`)
- [x] Explosion breaking waterlogged blocks (videos reference in GameModsBr#192)
- [x] Explosion now includes the water blocks from layer 1 in the events
- [x] Explosion not causing block update to blocks in layer 1
- [x] NullPointerException when trying to place a bucket of water in water (or an already waterlogged block)
- [x] Visual desync when you dump a water bucket in fences (and probably in some more waterloggable blocks)
- [x] BaseEntity.isInsideOfWater now returns true when the entity is inside a waterlogged block

History and Reference: GameModsBr#196 