### PR TITLE
[2.0] Fix level.dat loading

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -330,10 +330,6 @@ public class Server {
 
         this.consoleThread.start();
 
-        //todo: VersionString 现在不必要
-
-        log.debug("Directory: {}", this.dataPath);
-
         if (!new File(this.dataPath + "nukkit.yml").exists()) {
             log.info(TextFormat.GREEN + "Welcome! Please choose a language first!");
 
@@ -384,6 +380,19 @@ public class Server {
         this.config = new Config(this.dataPath + "nukkit.yml", Config.YAML);
 
         ignoredPackets.addAll(getConfig().getStringList("debug.ignored-packets"));
+
+        Nukkit.DEBUG = Math.max(this.getConfig("debug.level", 1), 1);
+
+        int logLevel = (Nukkit.DEBUG + 3) * 100;
+        for (org.apache.logging.log4j.Level level : org.apache.logging.log4j.Level.values()) {
+            if (level.intLevel() == logLevel) {
+                if (level.intLevel() > Nukkit.getLogLevel().intLevel()) {
+                    Nukkit.setLogLevel(level);
+                }
+                break;
+            }
+        }
+        log.debug("DataPath Directory: {}", this.dataPath);
 
         log.info("Loading {} ...", TextFormat.GREEN + "server.properties" + TextFormat.WHITE);
         this.properties = new Properties();
@@ -474,18 +483,6 @@ public class Server {
 
         if (this.getPropertyBoolean("hardcore", false) && this.getDifficulty() < 3) {
             this.setPropertyInt("difficulty", 3);
-        }
-
-        Nukkit.DEBUG = Math.max(this.getConfig("debug.level", 1), 1);
-
-        int logLevel = (Nukkit.DEBUG + 3) * 100;
-        for (org.apache.logging.log4j.Level level : org.apache.logging.log4j.Level.values()) {
-            if (level.intLevel() == logLevel) {
-                if (level.intLevel() > Nukkit.getLogLevel().intLevel()) {
-                    Nukkit.setLogLevel(level);
-                }
-                break;
-            }
         }
 
         if (this.getConfig().getBoolean("bug-report", true)) {

--- a/src/main/java/cn/nukkit/level/provider/leveldb/serializer/LevelDBDataSerializer.java
+++ b/src/main/java/cn/nukkit/level/provider/leveldb/serializer/LevelDBDataSerializer.java
@@ -152,11 +152,12 @@ public class LevelDBDataSerializer implements LevelDataSerializer {
         Map<String, Object> tagMap = tag.parseValue();
         GameRuleRegistry.get().getRules().forEach(rule -> {
             Object value = tagMap.get(rule.getName().toLowerCase());
-            if (value instanceof Byte) {
-                data.getGameRules().put((GameRule<Boolean>) rule, (byte) value != 0);
-            } else if (value instanceof Integer) {
+            Class type = rule.getValueClass();
+            if (type == Boolean.class) {
+                data.getGameRules().put((GameRule<Boolean>) rule, (int) value != 0);
+            } else if (type == Integer.class) {
                 data.getGameRules().put((GameRule<Integer>) rule, (int) value);
-            } else if (value instanceof Float) {
+            } else if (type == Float.class) {
                 data.getGameRules().put((GameRule<Float>) rule, (float) value);
             }
         });


### PR DESCRIPTION
the try with resources block was closing the channel on the InputStream before NBT tag was read

I also adjusted where the server debug level is set, as some debug logs were being sent and never actually seen, as well as removing a todo that had already been implemented