### PR TITLE
Native LevelDB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,16 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>daporkchop-repo</id>
+            <url>https://maven.daporkchop.net/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
     <distributionManagement>
@@ -204,13 +214,17 @@
             <version>21.0</version>
         </dependency>
         <dependency>
-            <groupId>org.iq80.leveldb</groupId>
-            <artifactId>leveldb</artifactId>
-            <version>0.11-SNAPSHOT</version>
+            <groupId>net.daporkchop</groupId>
+            <artifactId>leveldb-mcpe-jni</artifactId>
+            <version>0.0.2-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-buffer</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -66,10 +66,10 @@ import com.google.common.collect.ImmutableMap;
 import com.spotify.futures.CompletableFutures;
 import io.netty.buffer.ByteBuf;
 import lombok.extern.log4j.Log4j2;
+import net.daporkchop.ldbjni.LevelDB;
 import org.iq80.leveldb.CompressionType;
 import org.iq80.leveldb.DB;
 import org.iq80.leveldb.Options;
-import org.iq80.leveldb.impl.Iq80DBFactory;
 
 import java.io.*;
 import java.net.InetAddress;
@@ -502,7 +502,7 @@ public class Server {
 
         // Convert legacy data before plugins get the chance to mess with it.
         try {
-            nameLookup = Iq80DBFactory.factory.open(new File(dataPath, "players"), new Options()
+            nameLookup = LevelDB.PROVIDER.open(new File(dataPath, "players"), new Options()
                     .createIfMissing(true)
                     .compressionType(CompressionType.ZLIB_RAW));
         } catch (IOException e) {

--- a/src/main/java/cn/nukkit/level/provider/leveldb/LevelDBProvider.java
+++ b/src/main/java/cn/nukkit/level/provider/leveldb/LevelDBProvider.java
@@ -8,8 +8,8 @@ import cn.nukkit.level.provider.leveldb.serializer.*;
 import cn.nukkit.utils.LoadState;
 import com.google.common.base.Preconditions;
 import lombok.extern.log4j.Log4j2;
+import net.daporkchop.ldbjni.LevelDB;
 import org.iq80.leveldb.*;
-import org.iq80.leveldb.impl.Iq80DBFactory;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.IOException;
@@ -42,7 +42,7 @@ class LevelDBProvider implements LevelProvider {
                 .createIfMissing(true)
                 .compressionType(CompressionType.ZLIB_RAW)
                 .blockSize(64 * 1024);
-        this.db = Iq80DBFactory.factory.open(dbPath.toFile(), options);
+        this.db = LevelDB.PROVIDER.open(dbPath.toFile(), options);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/registry/RegistryProvider.java
+++ b/src/main/java/cn/nukkit/registry/RegistryProvider.java
@@ -20,7 +20,6 @@ public class RegistryProvider<T> implements Comparable<RegistryProvider<T>> {
         return value;
     }
 
-    @Nonnull
     public Plugin getPlugin() {
         return plugin;
     }


### PR DESCRIPTION
This makes NukkitX use Mojang's [leveldb-mcpe](https://github.com/Mojang/leveldb-mcpe) by default using [my JNI bindings](https://github.com/2pocket2edition/leveldb-mcpe-jni), falling back to [normal Java leveldb](https://github.com/dain/leveldb) if native libraries are not compiled for the current system.

Native libraries are available for the following platforms:
- Linux amd64
- Linux aarch64
- Linux armhf (Raspbian)
- Windows amd64

I added my Maven repo to `pom.xml`, if that's an issue I'll see if I can figure out how to publish artifacts to a remote repository.