### PR TITLE
Always save all chunks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <dependency>
             <groupId>net.daporkchop</groupId>
             <artifactId>leveldb-mcpe-jni</artifactId>
-            <version>0.0.4-SNAPSHOT</version>
+            <version>0.0.5-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>

--- a/src/main/java/cn/nukkit/level/chunk/Chunk.java
+++ b/src/main/java/cn/nukkit/level/chunk/Chunk.java
@@ -523,7 +523,11 @@ public final class Chunk implements IChunk, Closeable {
         //todo
     }
 
-    public LockableChunk lockable() {
+    public LockableChunk readLockable() {
+        return new LockableChunk(unsafe, lock.readLock());
+    }
+
+    public LockableChunk writeLockable() {
         return new LockableChunk(unsafe, lock.writeLock());
     }
 

--- a/src/main/java/cn/nukkit/level/chunk/IChunk.java
+++ b/src/main/java/cn/nukkit/level/chunk/IChunk.java
@@ -15,7 +15,7 @@ import java.util.Collection;
 
 import static cn.nukkit.block.BlockIds.AIR;
 
-public interface IChunk {
+public interface IChunk extends Comparable<IChunk> {
     @Nonnull
     ChunkSection getOrCreateSection(@Nonnegative int y);
 
@@ -259,4 +259,11 @@ public interface IChunk {
      * Clear chunk to a state as if it was not generated.
      */
     void clear();
+
+    @Override
+    default int compareTo(IChunk o) {
+        //compare x positions, and use z position to break ties
+        int x = Integer.compare(this.getX(), o.getX());
+        return x != 0 ? x : Integer.compare(this.getZ(), o.getZ());
+    }
 }

--- a/src/main/java/cn/nukkit/level/generator/PopChunkManager.java
+++ b/src/main/java/cn/nukkit/level/generator/PopChunkManager.java
@@ -42,8 +42,8 @@ public class PopChunkManager extends SimpleChunkManager {
         int chunkX = chunk.getX();
         int chunkZ = chunk.getZ();
         if (clean) {
-            CX = chunkX;
-            CZ = chunkZ;
+            CX = chunkX + 1; //this method is called with sorted chunks, meaning the first chunk is the one with the lowest position
+            CZ = chunkZ + 1;
             clean = false;
         }
 

--- a/src/main/java/cn/nukkit/level/generator/function/ChunkGenerateFunction.java
+++ b/src/main/java/cn/nukkit/level/generator/function/ChunkGenerateFunction.java
@@ -29,7 +29,7 @@ public class ChunkGenerateFunction implements Function<Chunk, Chunk> {
             return chunk;
         }
 
-        LockableChunk lockableChunk = chunk.lockable();
+        LockableChunk lockableChunk = chunk.writeLockable();
 
         BedrockRandom random = BedrockRandom.getThreadLocal();
         long seed = Generator.getChunkSeed(chunk.getX(), chunk.getZ(), this.level.getSeed());
@@ -40,7 +40,6 @@ public class ChunkGenerateFunction implements Function<Chunk, Chunk> {
             generator.generateChunk(random, chunk);
             chunk.setGenerated();
         } finally {
-            chunk.setDirty(false);
             lockableChunk.unlock();
         }
         return chunk;


### PR DESCRIPTION
Removed calls to `setDirty(false)` after generation and population, ensuring that chunks are always saved. This is no longer a significant performance concern with native leveldb, and will be critical to ensuring consistent population behavior for #1073 and related PRs. Additionally, ensures that chunks will always be locked in a predictable order before population, solving a potential deadlock.