### PR TITLE
Lock chunks for saving

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <dependency>
             <groupId>net.daporkchop</groupId>
             <artifactId>leveldb-mcpe-jni</artifactId>
-            <version>0.0.4-SNAPSHOT</version>
+            <version>0.0.5-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>

--- a/src/main/java/cn/nukkit/level/chunk/Chunk.java
+++ b/src/main/java/cn/nukkit/level/chunk/Chunk.java
@@ -523,7 +523,11 @@ public final class Chunk implements IChunk, Closeable {
         //todo
     }
 
-    public LockableChunk lockable() {
+    public LockableChunk readLockable() {
+        return new LockableChunk(unsafe, lock.readLock());
+    }
+
+    public LockableChunk writeLockable() {
         return new LockableChunk(unsafe, lock.writeLock());
     }
 

--- a/src/main/java/cn/nukkit/level/chunk/Chunk.java
+++ b/src/main/java/cn/nukkit/level/chunk/Chunk.java
@@ -469,6 +469,11 @@ public final class Chunk implements IChunk, Closeable {
         return unsafe.isDirty();
     }
 
+    @Override
+    public boolean clearDirty() {
+        return this.unsafe.clearDirty();
+    }
+
     public static short blockKey(Vector3i vector) {
         return blockKey(vector.x, vector.y, vector.z);
     }

--- a/src/main/java/cn/nukkit/level/chunk/IChunk.java
+++ b/src/main/java/cn/nukkit/level/chunk/IChunk.java
@@ -15,7 +15,7 @@ import java.util.Collection;
 
 import static cn.nukkit.block.BlockIds.AIR;
 
-public interface IChunk {
+public interface IChunk extends Comparable<IChunk> {
     @Nonnull
     ChunkSection getOrCreateSection(@Nonnegative int y);
 
@@ -259,4 +259,11 @@ public interface IChunk {
      * Clear chunk to a state as if it was not generated.
      */
     void clear();
+
+    @Override
+    default int compareTo(IChunk o) {
+        //compare x positions, and use z position to break ties
+        int x = Integer.compare(this.getX(), o.getX());
+        return x != 0 ? x : Integer.compare(this.getZ(), o.getZ());
+    }
 }

--- a/src/main/java/cn/nukkit/level/chunk/IChunk.java
+++ b/src/main/java/cn/nukkit/level/chunk/IChunk.java
@@ -256,6 +256,13 @@ public interface IChunk extends Comparable<IChunk> {
     void setDirty(boolean dirty);
 
     /**
+     * Atomically resets this chunk's dirty status.
+     *
+     * @return whether or not the chunk was previously dirty
+     */
+    boolean clearDirty();
+
+    /**
      * Clear chunk to a state as if it was not generated.
      */
     void clear();

--- a/src/main/java/cn/nukkit/level/chunk/LockableChunk.java
+++ b/src/main/java/cn/nukkit/level/chunk/LockableChunk.java
@@ -267,6 +267,11 @@ public final class LockableChunk implements IChunk, Lock {
     }
 
     @Override
+    public boolean clearDirty() {
+        return this.unsafe.clearDirty();
+    }
+
+    @Override
     public void clear() {
         this.unsafe.clear();
     }

--- a/src/main/java/cn/nukkit/level/chunk/UnsafeChunk.java
+++ b/src/main/java/cn/nukkit/level/chunk/UnsafeChunk.java
@@ -460,6 +460,11 @@ public final class UnsafeChunk implements IChunk, Closeable {
         DIRTY_FIELD.set(this, dirty ? 1 : 0);
     }
 
+    @Override
+    public boolean clearDirty() {
+        return DIRTY_FIELD.compareAndSet(this, 1, 0);
+    }
+
     /**
      * Clear chunk to a state as if it was not generated.
      */

--- a/src/main/java/cn/nukkit/level/generator/PopChunkManager.java
+++ b/src/main/java/cn/nukkit/level/generator/PopChunkManager.java
@@ -42,8 +42,8 @@ public class PopChunkManager extends SimpleChunkManager {
         int chunkX = chunk.getX();
         int chunkZ = chunk.getZ();
         if (clean) {
-            CX = chunkX;
-            CZ = chunkZ;
+            CX = chunkX + 1; //this method is called with sorted chunks, meaning the first chunk is the one with the lowest position
+            CZ = chunkZ + 1;
             clean = false;
         }
 

--- a/src/main/java/cn/nukkit/level/generator/function/ChunkGenerateFunction.java
+++ b/src/main/java/cn/nukkit/level/generator/function/ChunkGenerateFunction.java
@@ -29,7 +29,7 @@ public class ChunkGenerateFunction implements Function<Chunk, Chunk> {
             return chunk;
         }
 
-        LockableChunk lockableChunk = chunk.lockable();
+        LockableChunk lockableChunk = chunk.writeLockable();
 
         BedrockRandom random = BedrockRandom.getThreadLocal();
         long seed = Generator.getChunkSeed(chunk.getX(), chunk.getZ(), this.level.getSeed());
@@ -40,7 +40,6 @@ public class ChunkGenerateFunction implements Function<Chunk, Chunk> {
             generator.generateChunk(random, chunk);
             chunk.setGenerated();
         } finally {
-            chunk.setDirty(false);
             lockableChunk.unlock();
         }
         return chunk;

--- a/src/main/java/cn/nukkit/level/manager/LevelChunkManager.java
+++ b/src/main/java/cn/nukkit/level/manager/LevelChunkManager.java
@@ -262,7 +262,7 @@ public final class LevelChunkManager {
         Preconditions.checkNotNull(chunk, "chunk");
         Preconditions.checkArgument(chunk.getLevel() == this.level,
                 "Chunk is not from this ChunkManager's Level");
-        if (chunk.clearDirty()) {
+        if (chunk.isDirty()) {
             return this.provider.saveChunk(chunk).exceptionally(throwable -> {
                 log.warn("Unable to save chunk", throwable);
                 return null;

--- a/src/main/java/cn/nukkit/level/manager/LevelChunkManager.java
+++ b/src/main/java/cn/nukkit/level/manager/LevelChunkManager.java
@@ -262,8 +262,7 @@ public final class LevelChunkManager {
         Preconditions.checkNotNull(chunk, "chunk");
         Preconditions.checkArgument(chunk.getLevel() == this.level,
                 "Chunk is not from this ChunkManager's Level");
-        if (chunk.isDirty()) {
-            chunk.setDirty(false);
+        if (chunk.clearDirty()) {
             return this.provider.saveChunk(chunk).exceptionally(throwable -> {
                 log.warn("Unable to save chunk", throwable);
                 return null;

--- a/src/main/java/cn/nukkit/level/provider/leveldb/LevelDBProvider.java
+++ b/src/main/java/cn/nukkit/level/provider/leveldb/LevelDBProvider.java
@@ -84,6 +84,11 @@ class LevelDBProvider implements LevelProvider {
         final int z = chunk.getZ();
 
         return CompletableFuture.supplyAsync(() -> {
+            //we clear the dirty flag here instead of in LevelChunkManager in case there are modifications to the chunk between now and the time it was enqueued
+            if (!chunk.clearDirty()) {
+                //the chunk was not dirty, do nothing
+                return null;
+            }
             try (WriteBatch batch = this.db.createWriteBatch()) {
                 LockableChunk lockableChunk = chunk.readLockable();
                 lockableChunk.lock();

--- a/src/main/java/cn/nukkit/level/provider/leveldb/LevelDBProvider.java
+++ b/src/main/java/cn/nukkit/level/provider/leveldb/LevelDBProvider.java
@@ -3,6 +3,7 @@ package cn.nukkit.level.provider.leveldb;
 import cn.nukkit.level.LevelData;
 import cn.nukkit.level.chunk.Chunk;
 import cn.nukkit.level.chunk.ChunkBuilder;
+import cn.nukkit.level.chunk.LockableChunk;
 import cn.nukkit.level.provider.LevelProvider;
 import cn.nukkit.level.provider.leveldb.serializer.*;
 import cn.nukkit.utils.LoadState;
@@ -83,18 +84,27 @@ class LevelDBProvider implements LevelProvider {
         final int z = chunk.getZ();
 
         return CompletableFuture.supplyAsync(() -> {
-            WriteBatch batch = this.db.createWriteBatch();
+            try (WriteBatch batch = this.db.createWriteBatch()) {
+                LockableChunk lockableChunk = chunk.readLockable();
+                lockableChunk.lock();
+                try {
+                    ChunkSerializers.serializeChunk(batch, chunk, 7);
+                    Data2dSerializer.serialize(batch, chunk);
 
-            ChunkSerializers.serializeChunk(batch, chunk, 7);
-            Data2dSerializer.serialize(batch, chunk);
+                    batch.put(LevelDBKey.VERSION.getKey(x, z), new byte[]{7});
 
-            batch.put(LevelDBKey.VERSION.getKey(x, z), new byte[]{7});
+                    BlockEntitySerializer.saveBlockEntities(batch, chunk);
+                    EntitySerializer.saveEntities(batch, chunk);
+                } finally {
+                    lockableChunk.unlock();
+                }
 
-            BlockEntitySerializer.saveBlockEntities(batch, chunk);
-            EntitySerializer.saveEntities(batch, chunk);
-
-            this.db.write(batch);
-            return null;
+                this.db.write(batch);
+                return null;
+            } catch (IOException e) {
+                //can't happen
+                throw new RuntimeException(e);
+            }
         }, this.executor);
     }
 


### PR DESCRIPTION
Obtain a read-only lock on chunks before encoding them (the writing part is done outside of the lock). This should prevent (among other things) air-only chunks from being saved.

Depends on #1207.