### PR TITLE
[2.0] Fix crash when waterlogged flowing water meets still water

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockLava.java
+++ b/src/main/java/cn/nukkit/block/BlockLava.java
@@ -29,8 +29,12 @@ import static cn.nukkit.block.BlockIds.*;
  */
 public class BlockLava extends BlockLiquid {
 
-    public BlockLava(Identifier id) {
-        super(id);
+    protected BlockLava(Identifier id, Identifier flowingId, Identifier stationaryId) {
+        super(id, flowingId, stationaryId);
+    }
+
+    protected BlockLava(Identifier flowingId, Identifier stationaryId) {
+        this(flowingId, flowingId, stationaryId);
     }
 
     @Override
@@ -189,5 +193,10 @@ public class BlockLava extends BlockLiquid {
         if (!(entity instanceof Tnt)) {
             super.addVelocityToEntity(entity, vector);
         }
+    }
+
+
+    public static BlockFactory factory(Identifier stationaryId) {
+        return id-> new BlockLava(id, stationaryId);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockLavaStill.java
+++ b/src/main/java/cn/nukkit/block/BlockLavaStill.java
@@ -11,8 +11,12 @@ import static cn.nukkit.block.BlockIds.LAVA;
  */
 public class BlockLavaStill extends BlockLava {
 
-    public BlockLavaStill(Identifier id) {
-        super(id);
+    protected BlockLavaStill(Identifier id, Identifier flowingId, Identifier stationaryId) {
+        super(id, flowingId, stationaryId);
+    }
+
+    protected BlockLavaStill(Identifier flowingId, Identifier stationaryId) {
+        this(stationaryId, flowingId, stationaryId);
     }
 
     @Override
@@ -26,5 +30,9 @@ public class BlockLavaStill extends BlockLava {
             return super.onUpdate(type);
         }
         return 0;
+    }
+
+    public static BlockFactory factory(Identifier flowingId) {
+        return id-> new BlockLavaStill(flowingId, id);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockLiquid.java
+++ b/src/main/java/cn/nukkit/block/BlockLiquid.java
@@ -107,7 +107,7 @@ public abstract class BlockLiquid extends BlockTransparent {
 
     protected int getFlowDecay(Block block) {
         if (!isSameLiquid(block.getId())) {
-            if (block.isWaterlogged()) {
+            if (block.getLayer() != 1 && block.isWaterlogged()) {
                 return getFlowDecay(this.getLiquidBlock(block));
             }
             return -1;

--- a/src/main/java/cn/nukkit/block/BlockLiquid.java
+++ b/src/main/java/cn/nukkit/block/BlockLiquid.java
@@ -28,15 +28,19 @@ import static cn.nukkit.block.BlockIds.AIR;
 
 public abstract class BlockLiquid extends BlockTransparent {
 
-    private final byte CAN_FLOW_DOWN = 1;
-    private final byte CAN_FLOW = 0;
-    private final byte BLOCKED = -1;
+    private static final byte CAN_FLOW_DOWN = 1;
+    private static final byte CAN_FLOW = 0;
+    private static final byte BLOCKED = -1;
+    protected final Identifier flowingId;
+    protected final Identifier stationaryId;
     public int adjacentSources = 0;
     protected Vector3f flowVector = null;
     private Long2ByteMap flowCostVisited = new Long2ByteOpenHashMap();
 
-    public BlockLiquid(Identifier id) {
+    public BlockLiquid(Identifier id, Identifier flowingId, Identifier stationaryId) {
         super(id);
+        this.flowingId = flowingId;
+        this.stationaryId = stationaryId;
     }
 
     @Override
@@ -102,7 +106,7 @@ public abstract class BlockLiquid extends BlockTransparent {
     }
 
     protected int getFlowDecay(Block block) {
-        if (block.getId() != this.getId()) {
+        if (!isSameLiquid(block.getId())) {
             if (block.isWaterlogged()) {
                 return getFlowDecay(this.getLiquidBlock(block));
             }
@@ -112,7 +116,7 @@ public abstract class BlockLiquid extends BlockTransparent {
     }
 
     protected int getEffectiveFlowDecay(Block block) {
-        if (block.getId() != this.getId()) {
+        if (!isSameLiquid(block.getId())) {
             return -1;
         }
         int decay = block.getDamage();
@@ -490,5 +494,17 @@ public abstract class BlockLiquid extends BlockTransparent {
 
     public boolean usesWaterLogging() {
         return false;
+    }
+
+    public boolean isSameLiquid(Identifier other) {
+        return other == getFlowingId() || other == getStationaryId();
+    }
+
+    public Identifier getFlowingId() {
+        return flowingId;
+    }
+
+    public Identifier getStationaryId() {
+        return stationaryId;
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockWater.java
+++ b/src/main/java/cn/nukkit/block/BlockWater.java
@@ -16,8 +16,12 @@ import static cn.nukkit.block.BlockIds.FLOWING_WATER;
  */
 public class BlockWater extends BlockLiquid {
 
-    public BlockWater(Identifier id) {
-        super(id);
+    protected BlockWater(Identifier id, Identifier flowingId, Identifier stationaryId) {
+        super(id, flowingId, stationaryId);
+    }
+
+    protected BlockWater(Identifier flowingId, Identifier stationaryId) {
+        this(flowingId, flowingId, stationaryId);
     }
 
     @Override
@@ -55,5 +59,9 @@ public class BlockWater extends BlockLiquid {
     @Override
     public boolean usesWaterLogging() {
         return true;
+    }
+
+    public static BlockFactory factory(Identifier stationaryId) {
+        return id-> new BlockWater(id, stationaryId);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockWaterStill.java
+++ b/src/main/java/cn/nukkit/block/BlockWaterStill.java
@@ -10,8 +10,12 @@ import static cn.nukkit.block.BlockIds.WATER;
  */
 public class BlockWaterStill extends BlockWater {
 
-    public BlockWaterStill(Identifier id) {
-        super(id);
+    protected BlockWaterStill(Identifier id, Identifier flowingId, Identifier stationaryId) {
+        super(id, flowingId, stationaryId);
+    }
+
+    protected BlockWaterStill(Identifier flowingId, Identifier stationaryId) {
+        this(stationaryId, flowingId, stationaryId);
     }
 
     @Override
@@ -19,4 +23,7 @@ public class BlockWaterStill extends BlockWater {
         return Block.get(WATER, meta);
     }
 
+    public static BlockFactory factory(Identifier flowingId) {
+        return id-> new BlockWaterStill(flowingId, id);
+    }
 }

--- a/src/main/java/cn/nukkit/registry/BlockRegistry.java
+++ b/src/main/java/cn/nukkit/registry/BlockRegistry.java
@@ -263,10 +263,10 @@ public class BlockRegistry implements Registry {
         this.factoryMap.put(PLANKS, BlockPlanks::new); //5
         this.factoryMap.put(SAPLING, BlockSapling::new); //6
         this.factoryMap.put(BEDROCK, BlockBedrock::new); //7
-        this.factoryMap.put(FLOWING_WATER, BlockWater::new); //8
-        this.factoryMap.put(WATER, BlockWaterStill::new); //9
-        this.factoryMap.put(FLOWING_LAVA, BlockLava::new); //10
-        this.factoryMap.put(LAVA, BlockLavaStill::new); //11
+        this.factoryMap.put(FLOWING_WATER, BlockWater.factory(WATER)); //8
+        this.factoryMap.put(WATER, BlockWaterStill.factory(FLOWING_WATER)); //9
+        this.factoryMap.put(FLOWING_LAVA, BlockLava.factory(LAVA)); //10
+        this.factoryMap.put(LAVA, BlockLavaStill.factory(FLOWING_LAVA)); //11
         this.factoryMap.put(SAND, BlockSand::new); //12
         this.factoryMap.put(GRAVEL, BlockGravel::new); //13
         this.factoryMap.put(GOLD_ORE, BlockOreGold::new); //14


### PR DESCRIPTION
I was getting kinda random crashes while I was testing stuff under the ocean:
```java
java.lang.StackOverflowError: null
	at cn.nukkit.level.manager.LevelChunkManager.getLoadedChunk(LevelChunkManager.java:104) ~[classes/:?]
	at cn.nukkit.level.manager.LevelChunkManager.getLoadedChunk(LevelChunkManager.java:117) ~[classes/:?]
	at cn.nukkit.level.manager.LevelChunkManager.getChunk(LevelChunkManager.java:134) ~[classes/:?]
	at cn.nukkit.level.manager.LevelChunkManager.getChunk(LevelChunkManager.java:129) ~[classes/:?]
	at cn.nukkit.level.Level.getChunk(Level.java:2227) ~[classes/:?]
	at cn.nukkit.level.Level.getBlock(Level.java:1332) ~[classes/:?]
	at cn.nukkit.level.Level.getBlock(Level.java:1315) ~[classes/:?]
	at cn.nukkit.block.BlockLiquid.getLiquidBlock(BlockLiquid.java:446) ~[classes/:?]
	at cn.nukkit.block.BlockLiquid.getFlowDecay(BlockLiquid.java:107) ~[classes/:?]
	at cn.nukkit.block.BlockLiquid.getFlowDecay(BlockLiquid.java:107) ~[classes/:?]
	at cn.nukkit.block.BlockLiquid.getFlowDecay(BlockLiquid.java:107) ~[classes/:?]
	at cn.nukkit.block.BlockLiquid.getFlowDecay(BlockLiquid.java:107) ~[classes/:?]
// a huge repetition of at cn.nukkit.block.BlockLiquid.getFlowDecay(BlockLiquid.java:107) ~
[classes/:?]
// then a thread dump
```
https://hastebin.com/egiraginig.cs

I found that when `minecraft:flowing_water` which was in layer 1 attempts to interact with `minecraft:water` which is in layer 0, an infinite loop happens some times. The same happens when `water` attempts to interact to `flowing_water` in the same conditions.

I fixed it making the liquid implementation aware of both flowing and still ids, and considering them the same liquid.

It also fixes this weird interaction between still and flowing water:
https://gfycat.com/ClearcutCraftyAlbacoretuna

Reference: GameModsBr#204