### PR TITLE
Use static Gson instance in FormWindow

### DIFF
--- a/src/main/java/cn/nukkit/form/window/FormWindow.java
+++ b/src/main/java/cn/nukkit/form/window/FormWindow.java
@@ -5,10 +5,12 @@ import com.google.gson.Gson;
 
 public abstract class FormWindow {
 
+    private static final Gson GSON = new Gson();
+    
     protected boolean closed = false;
 
-    public String getJSONData(){
-        return new Gson().toJson(this);
+    public String getJSONData() {
+        return FormWindow.GSON.toJson(this);
     }
 
     public abstract void setResponse(String data);


### PR DESCRIPTION
Always creating a new Gson instance on every Json request is very unperformant.
(see https://github.com/google/gson/blob/master/gson/src/main/java/com/google/gson/Gson.java#L195)