### PR TITLE
Speed up `Identifier` lookups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,16 +39,6 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
-        <repository>
-            <id>daporkchop-repo</id>
-            <url>https://maven.daporkchop.net/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
     </repositories>
 
     <distributionManagement>

--- a/src/main/java/cn/nukkit/utils/Identifier.java
+++ b/src/main/java/cn/nukkit/utils/Identifier.java
@@ -2,20 +2,36 @@ package cn.nukkit.utils;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import net.daporkchop.lib.common.cache.Cache;
+import net.daporkchop.lib.common.cache.ThreadCache;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class Identifier implements Comparable<Identifier> {
-    public static final Identifier EMPTY = new Identifier("", "", ":");
-
-    private static final Pattern PATTERN = Pattern.compile("^([a-zA-Z0-9_]+):([a-zA-Z0-9_.]+)$");
-    private static final ConcurrentMap<String, Identifier> VALUES = new ConcurrentHashMap<>();
     private static final char NAMESPACE_SEPARATOR = ':';
 
+    public static final Identifier EMPTY = new Identifier("", "", "" + NAMESPACE_SEPARATOR);
+
+    private static final Pattern PATTERN = Pattern.compile("^(?>minecraft:)?(?>([a-z0-9_]*)" + NAMESPACE_SEPARATOR + ")?([a-z0-9_]*)$");
+    private static final Cache<Matcher> MATCHER_CACHE = ThreadCache.soft(() -> PATTERN.matcher(""));
+
+    private static final Lock READ_LOCK;
+    private static final Lock WRITE_LOCK;
+
+    private static final Map<String, Identifier> VALUES = new HashMap<>();
+
     static {
-        VALUES.put(EMPTY.fullName, EMPTY);
+        ReadWriteLock lock = new ReentrantReadWriteLock();
+        READ_LOCK = lock.readLock();
+        WRITE_LOCK = lock.writeLock();
     }
 
     private final String namespace;
@@ -29,28 +45,55 @@ public final class Identifier implements Comparable<Identifier> {
     }
 
     public static Identifier fromString(String identifier) {
-        Preconditions.checkNotNull(identifier, "identifier");
-        String[] parts = identifier.split(":");
-
-        if (parts.length == 1) {
-            return from("minecraft", parts[0]);
-        } else if (parts.length > 1) {
-            return from(parts[0], parts[1]);
+        if (Preconditions.checkNotNull(identifier, "identifier").isEmpty()) {
+            //check for empty before using matcher
+            return EMPTY;
         }
-        throw new IllegalArgumentException("Invalid identifier");
+        Matcher matcher = MATCHER_CACHE.get().reset(identifier);
+        Preconditions.checkArgument(matcher.find(), "Invalid identifier: \"%s\"", identifier);
+
+        Identifier id;
+        READ_LOCK.lock();
+        try {
+            id = VALUES.get(identifier);
+        } finally {
+            READ_LOCK.unlock();
+        }
+
+        if (id == null) {
+            String namespace = matcher.group(1);
+            String name = matcher.group(2);
+            String fullName = namespace == null && !identifier.startsWith("minecraft:") ? "minecraft:" + name : identifier;
+
+            //create new identifier instance
+            WRITE_LOCK.lock();
+            try {
+                //try get again in case identifier was created while obtaining write lock
+                if ((id = VALUES.get(identifier)) == null)  {
+                    id = new Identifier(namespace == null ? "minecraft" : namespace, name, fullName);
+                    if (namespace == null)  {
+                        //also put it into the map without minecraft: in the key to facilitate faster lookups when the prefix is omitted
+                        VALUES.put(name, id);
+                    }
+                    VALUES.put(fullName, id);
+                }
+            } finally {
+                WRITE_LOCK.unlock();
+            }
+        }
+        return id;
     }
 
     public static Identifier from(String space, String name) {
-        if (Strings.isNullOrEmpty(space) || Strings.isNullOrEmpty(name)) {
-            return EMPTY;
+        if (Strings.isNullOrEmpty(space)) {
+            if (Strings.isNullOrEmpty(name))    {
+                return EMPTY;
+            } else {
+                //assume minecraft namespace
+                return fromString(name);
+            }
         }
-        String spaceLower = space.toLowerCase();
-        String nameLower = name.toLowerCase();
-
-        final String fullName = space + NAMESPACE_SEPARATOR + name;
-        Preconditions.checkArgument(PATTERN.matcher(fullName).matches(), "Identifier (%s) contains invalid characters", fullName);
-
-        return VALUES.computeIfAbsent(fullName, s -> new Identifier(spaceLower, nameLower, fullName));
+        return fromString(space + NAMESPACE_SEPARATOR + name);
     }
 
     public String getName() {


### PR DESCRIPTION
This optimizes `Identifier#fromString` in a number of ways:

- Re-use `Matcher` instance rather than creating a new one each time
- Use normal `HashMap` instead of `ConcurrentHashMap` for faster operations
- Use a `ReadWriteLock` for controlling access to the internal map (ensures we can make the most of `HashMap`'s performance advantage by allowing multiple readers)
- Force all names to be lower-cased (avoids `String#toLowerCase`, users really shouldn't be using capitalized identifier names in the first place)
- Store identifiers under the `minecraft` namespace in the map both with and without their namespace (makes lookup faster when a string is given without a prefix)
- Make `fromString(String)` contain the main method implementation, and `from(String, String)` be a proxy to `fromString(String)` since `fromString(String)` is almost exclusively the only one used