### PR TITLE
[2.0] Location and Teleport fixes

### DIFF
--- a/src/main/java/cn/nukkit/command/CommandUtils.java
+++ b/src/main/java/cn/nukkit/command/CommandUtils.java
@@ -35,9 +35,9 @@ public class CommandUtils {
     public static float getPosition(String pos, float relative) throws IllegalArgumentException {
         Matcher matcher = RELATIVE_PATTERN.matcher(pos);
         checkArgument(matcher.matches(), "Invalid position");
-        float position = Float.parseFloat(matcher.group(matcher.groupCount()));
+        float position = Float.parseFloat(matcher.group(2));
 
-        if (matcher.groupCount() > 1) {
+        if (matcher.group(1) != null) {
             position += relative;
         }
         return position;

--- a/src/main/java/cn/nukkit/command/defaults/SetWorldSpawnCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/SetWorldSpawnCommand.java
@@ -35,7 +35,7 @@ public class SetWorldSpawnCommand extends VanillaCommand {
         if (args.length == 0) {
             if (sender instanceof Player) {
                 level = ((Player) sender).getLevel();
-                pos = ((Player) sender).getPosition().floor();
+                pos = ((Player) sender).getPosition();
             } else {
                 sender.sendMessage(new TranslationContainer("commands.generic.ingame"));
                 return true;

--- a/src/main/java/cn/nukkit/command/defaults/SetWorldSpawnCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/SetWorldSpawnCommand.java
@@ -35,7 +35,7 @@ public class SetWorldSpawnCommand extends VanillaCommand {
         if (args.length == 0) {
             if (sender instanceof Player) {
                 level = ((Player) sender).getLevel();
-                pos = ((Player) sender).getPosition().round();
+                pos = ((Player) sender).getPosition().floor();
             } else {
                 sender.sendMessage(new TranslationContainer("commands.generic.ingame"));
                 return true;

--- a/src/main/java/cn/nukkit/command/defaults/TeleportCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/TeleportCommand.java
@@ -34,10 +34,10 @@ public class TeleportCommand extends VanillaCommand {
         });
         this.commandParameters.add(new CommandParameter[]{
                 new CommandParameter("player", CommandParamType.TARGET, false),
-                new CommandParameter("blockPos", CommandParamType.POSITION, false),
+                new CommandParameter("position", CommandParamType.POSITION, false),
         });
         this.commandParameters.add(new CommandParameter[]{
-                new CommandParameter("blockPos", CommandParamType.POSITION, false),
+                new CommandParameter("position", CommandParamType.POSITION, false),
         });
     }
 
@@ -56,7 +56,7 @@ public class TeleportCommand extends VanillaCommand {
             if (sender instanceof Player) {
                 target = sender;
             } else {
-                sender.sendMessage(new TranslationContainer("commands.generic.ingame"));
+                sender.sendMessage(new TranslationContainer("commands.locate.fail.noplayer"));
                 return true;
             }
             if (args.length == 1) {

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -2329,10 +2329,10 @@ public class Level implements ChunkManager, Metadatable {
             int x = v.getFloorX() & 0x0f;
             int z = v.getFloorZ() & 0x0f;
             if (chunk != null) {
-                int y = NukkitMath.clamp(v.getFloorX(), 0, 254);
-                boolean wasAir = chunk.getBlockId(x & 0xf, (y - 1) & 0xf, z & 0xf) == AIR;
+                int y = NukkitMath.clamp(v.getFloorY(), 0, 254);
+                boolean wasAir = !this.isFullBlock(chunk.getBlock(x, y + 1, z));
                 for (; y > 0; --y) {
-                    Block block = chunk.getBlock(x & 0xf, y & 0xf, z & 0xf);
+                    Block block = chunk.getBlock(x, y, z);
                     if (this.isFullBlock(block)) {
                         if (wasAir) {
                             y++;
@@ -2344,22 +2344,19 @@ public class Level implements ChunkManager, Metadatable {
                 }
 
                 for (; y >= 0 && y < 255; y++) {
-                    Block block = chunk.getBlock(x & 0xf, (y + 1), z & 0xf);
+                    Block block = chunk.getBlock(x, (y + 1), z);
                     if (!this.isFullBlock(block)) {
-                        block = chunk.getBlock(x & 0xf, y & 0xf, z & 0xf);
+                        block = chunk.getBlock(x, y, z);
                         if (!this.isFullBlock(block)) {
-                            return Location.from(spawn.getX(), y == (int) spawn.getY() ? spawn.getY() : y, spawn.getZ(),
-                                    spawn.getYaw(), spawn.getPitch(), this);
+                            return Location.from(spawn.getX(), y, spawn.getZ(), spawn.getYaw(), spawn.getPitch(), this);
                         }
-                    } else {
-                        ++y;
                     }
                 }
 
-                v = Vector3f.from(v.getX(), y, v.getZ());
+                v = Vector3f.from(spawn.getX(), y, spawn.getZ());
             }
 
-            return Location.from(spawn.getX(), v.getY(), spawn.getZ(), spawn.getY(), spawn.getPitch(), this);
+            return Location.from(v.getX(), v.getY(), v.getZ(), spawn.getYaw(), spawn.getPitch(), this);
         }
 
         return null;

--- a/src/main/java/cn/nukkit/level/Location.java
+++ b/src/main/java/cn/nukkit/level/Location.java
@@ -52,11 +52,11 @@ public final class Location {
     }
 
     public float getY() {
-        return this.position.getX();
+        return this.position.getY();
     }
 
     public float getZ() {
-        return this.position.getX();
+        return this.position.getZ();
     }
 
     public Vector3f getPosition() {

--- a/src/main/java/cn/nukkit/level/Location.java
+++ b/src/main/java/cn/nukkit/level/Location.java
@@ -84,11 +84,11 @@ public final class Location {
     }
 
     public Location add(double x, double y, double z) {
-        return Location.from(Vector3f.from(x, y, z), this.yaw, this.pitch, this.level);
+        return Location.from(Vector3f.from(this.getX() + x, this.getY() + y, this.getZ() + z), this.yaw, this.pitch, this.level);
     }
 
     public Location add(float x, float y, float z) {
-        return Location.from(Vector3f.from(x, y, z), this.yaw, this.pitch, this.level);
+        return Location.from(Vector3f.from(this.getX() + x, this.getY() + y, this.getZ() + z), this.yaw, this.pitch, this.level);
     }
 
     public int getFloorX() {

--- a/src/main/java/cn/nukkit/level/manager/LevelChunkManager.java
+++ b/src/main/java/cn/nukkit/level/manager/LevelChunkManager.java
@@ -294,6 +294,10 @@ public final class LevelChunkManager {
     }
 
     public synchronized void tick() {
+        if (this.chunks.isEmpty()) {
+            return;
+        }
+
         long time = System.currentTimeMillis();
 
         // Spawn chunk
@@ -315,7 +319,7 @@ public final class LevelChunkManager {
                     continue; // Chunk hasn't loaded
                 }
 
-                if (Math.abs(chunk.getX() - spawnX) <= spawnRadius || Math.abs(chunk.getZ() - spawnZ) <= spawnRadius ||
+                if ((Math.abs(chunk.getX() - spawnX) <= spawnRadius && Math.abs(chunk.getZ() - spawnZ) <= spawnRadius) ||
                         !chunk.getLoaders().isEmpty()) {
                     continue; // Spawn protection or is loaded
                 }
@@ -328,7 +332,7 @@ public final class LevelChunkManager {
 
                 long lastAccessTime = this.chunkLastAccessTimes.get(chunkKey);
                 if ((time - lastAccessTime) <= TimeUnit.SECONDS.toMillis(
-                        config.getInt("level-settings. chunk-timeout-after-last-access", 120))) {
+                        config.getInt("level-settings.chunk-timeout-after-last-access", 120))) {
                     continue;
                 }
 

--- a/src/main/java/cn/nukkit/player/Player.java
+++ b/src/main/java/cn/nukkit/player/Player.java
@@ -3071,7 +3071,7 @@ public class Player extends Human implements CommandSender, InventoryHolder, Chu
                     RespawnPacket respawnPacket = (RespawnPacket) packet;
                     if (respawnPacket.getState() == RespawnPacket.State.CLIENT_READY) {
                         RespawnPacket respawn1 = new RespawnPacket();
-                        respawn1.setPosition(this.getPosition());
+                        respawn1.setPosition(this.getSpawn().getPosition());
                         respawn1.setState(RespawnPacket.State.SERVER_READY);
                         this.sendPacket(respawn1);
                     }


### PR DESCRIPTION
*  Fixes the `getY()` and `getZ()` functions in `Location` (previously returned x value)
*  Fixes the `add()` function in the `Location` class
*  Fixes regex matching in the `CommandUtils` class (always has 2 groups based on pattern, but group(1) might be null)
* Updates `getSafeSpawn()`:
   *  find the correct 2 vertical air spaces in the (x, z) position
   *  remove redundant bitmasks, and incorrect bitmask of y value

