### PR TITLE
override addMoment in EntityHuman

### DIFF
--- a/src/main/java/cn/nukkit/entity/EntityHuman.java
+++ b/src/main/java/cn/nukkit/entity/EntityHuman.java
@@ -215,6 +215,11 @@ public class EntityHuman extends EntityHumanType {
     }
 
     @Override
+    public void addMovement(double x, double y, double z, double yaw, double pitch, double headYaw) {
+        this.level.addPlayerMovement(this, x, y, z, yaw, pitch, headYaw);
+    }
+
+    @Override
     public void spawnTo(Player player) {
         if (this != player && !this.hasSpawned.containsKey(player.getLoaderId())) {
             this.hasSpawned.put(player.getLoaderId(), player);

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -3204,6 +3204,19 @@ public class Level implements ChunkManager, Metadatable {
         this.server.getLevelMetadata().removeMetadata(this, metadataKey, owningPlugin);
     }
 
+    public void addPlayerMovement(Entity entity, double x, double y, double z, double yaw, double pitch, double headYaw) {
+        MovePlayerPacket pk = new MovePlayerPacket();
+        pk.eid = entity.getId();
+        pk.x = (float) x;
+        pk.y = (float) y;
+        pk.z = (float) z;
+        pk.yaw = (float) yaw;
+        pk.headYaw = (float) headYaw;
+        pk.pitch = (float) pitch;
+
+        Server.broadcastPacket(entity.getViewers().values(), pk);
+    }
+
     public void addEntityMovement(Entity entity, double x, double y, double z, double yaw, double pitch, double headYaw) {
         MoveEntityAbsolutePacket pk = new MoveEntityAbsolutePacket();
         pk.eid = entity.getId();


### PR DESCRIPTION
MovePlayerPacket instead of MoveEntityAbsolutePacket should be used when moving EntityHuman.