### PR TITLE
[2.0] Fix IndexOutOfBoundsException with negative coordinates

### DIFF
--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -2130,7 +2130,7 @@ public class Level implements ChunkManager, Metadatable {
     @Override
     public Block getBlockAt(int x, int y, int z, int layer) {
         Chunk chunk = this.getChunk(x >> 4, z >> 4);
-        return chunk.getBlock(x, y, z, layer);
+        return chunk.getBlock(x & 0x0f, y & 0xff, z & 0x0f, layer);
     }
 
     @Override
@@ -2234,7 +2234,7 @@ public class Level implements ChunkManager, Metadatable {
 
     public BlockColor getMapColorAt(int x, int z) {
         Chunk chunk = this.getChunk(x >> 4, z >> 4);
-        int y = chunk.getHighestBlock(x, z);
+        int y = chunk.getHighestBlock(x & 0x0f, z & 0x0f);
         while (y > 1) {
             Block block = getBlock(new BlockPosition(x, y, z));
             BlockColor blockColor = block.getColor();


### PR DESCRIPTION
Example:
```java
Level level = getLevel();
level.getBlockAt(0, 80, -4);
```

Produces:
```java
java.lang.IndexOutOfBoundsException: z coordinate (-5) must not be negative
	at com.google.common.base.Preconditions.checkElementIndex(Preconditions.java:1177)
	at cn.nukkit.level.chunk.UnsafeChunk.checkBounds(UnsafeChunk.java:99)
	at cn.nukkit.level.chunk.UnsafeChunk.checkBounds(UnsafeChunk.java:94)
	at cn.nukkit.level.chunk.UnsafeChunk.getBlock(UnsafeChunk.java:142)
	at cn.nukkit.level.chunk.Chunk.getBlock(Chunk.java:141)
	at cn.nukkit.level.Level.getBlockAt(Level.java:2133)
        at <caller>
```