### PR TITLE
[2.0] Entity fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
         <dependency>
             <groupId>com.nukkitx.protocol</groupId>
             <artifactId>bedrock-v389</artifactId>
-            <version>2.5.1</version>
+            <version>2.5.2</version>
         </dependency>
         <dependency>
             <groupId>com.nukkitx</groupId>

--- a/src/main/java/cn/nukkit/block/BlockBarrel.java
+++ b/src/main/java/cn/nukkit/block/BlockBarrel.java
@@ -102,6 +102,7 @@ public class BlockBarrel extends BlockSolid implements Faceable {
 
     public void setBlockFace(BlockFace face) {
         setMeta((getMeta() & 0x8) | (face.getIndex() & 0x7));
+        getLevel().setBlockDataAt(this.getX(), this.getY(), this.getZ(), this.getLayer(), getMeta());
     }
 
     public boolean isOpen() {
@@ -110,6 +111,7 @@ public class BlockBarrel extends BlockSolid implements Faceable {
 
     public void setOpen(boolean open) {
         setMeta((getMeta() & 0x7) | (open ? 0x8 : 0x0));
+        getLevel().setBlockDataAt(this.getX(), this.getY(), this.getZ(), this.getLayer(), getMeta());
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockBeacon.java
+++ b/src/main/java/cn/nukkit/block/BlockBeacon.java
@@ -53,9 +53,8 @@ public class BlockBeacon extends BlockTransparent {
     public boolean onActivate(Item item, Player player) {
         if (player != null) {
             BlockEntity t = this.getLevel().getBlockEntity(this.getPosition());
-            if (t instanceof Beacon) {
+            if (!(t instanceof Beacon)) {
                 t.close();
-            } else {
                 BlockEntityRegistry.get().newEntity(BEACON, this.getChunk(), this.getPosition());
             }
 

--- a/src/main/java/cn/nukkit/block/BlockBed.java
+++ b/src/main/java/cn/nukkit/block/BlockBed.java
@@ -17,6 +17,7 @@ import cn.nukkit.utils.Faceable;
 import cn.nukkit.utils.Identifier;
 import com.nukkitx.math.vector.Vector3f;
 import com.nukkitx.math.vector.Vector3i;
+import lombok.extern.log4j.Log4j2;
 
 import static cn.nukkit.block.BlockIds.AIR;
 import static cn.nukkit.block.BlockIds.BED;
@@ -25,6 +26,7 @@ import static cn.nukkit.block.BlockIds.BED;
  * author: MagicDroidX
  * Nukkit Project
  */
+@Log4j2
 public class BlockBed extends BlockTransparent implements Faceable {
 
     public BlockBed(Identifier id) {
@@ -111,11 +113,11 @@ public class BlockBed extends BlockTransparent implements Faceable {
     @Override
     public boolean place(Item item, Block block, Block target, BlockFace face, Vector3f clickPos, Player player) {
         Block down = this.down();
-        if (!down.isTransparent()) {
-            Block next = this.getSide(player.getDirection());
+        if (!down.isTransparent() || down instanceof BlockSlab) {
+            Block next = this.getSide(player.getHorizontalFacing());
             Block downNext = next.down();
 
-            if (next.canBeReplaced() && !downNext.isTransparent()) {
+            if (next.canBeReplaced() && (!downNext.isTransparent() || downNext instanceof BlockSlab)) {
                 int meta = player.getDirection().getHorizontalIndex();
 
                 this.getLevel().setBlock(block.getPosition(), Block.get(this.getId(), meta), true, true);

--- a/src/main/java/cn/nukkit/block/BlockBed.java
+++ b/src/main/java/cn/nukkit/block/BlockBed.java
@@ -17,7 +17,6 @@ import cn.nukkit.utils.Faceable;
 import cn.nukkit.utils.Identifier;
 import com.nukkitx.math.vector.Vector3f;
 import com.nukkitx.math.vector.Vector3i;
-import lombok.extern.log4j.Log4j2;
 
 import static cn.nukkit.block.BlockIds.AIR;
 import static cn.nukkit.block.BlockIds.BED;
@@ -26,7 +25,6 @@ import static cn.nukkit.block.BlockIds.BED;
  * author: MagicDroidX
  * Nukkit Project
  */
-@Log4j2
 public class BlockBed extends BlockTransparent implements Faceable {
 
     public BlockBed(Identifier id) {

--- a/src/main/java/cn/nukkit/block/BlockChest.java
+++ b/src/main/java/cn/nukkit/block/BlockChest.java
@@ -118,7 +118,6 @@ public class BlockChest extends BlockTransparent implements Faceable {
 
         if (chest != null) {
             chest.pairWith(chest1);
-            chest1.pairWith(chest);
         }
 
         return true;

--- a/src/main/java/cn/nukkit/block/BlockFurnace.java
+++ b/src/main/java/cn/nukkit/block/BlockFurnace.java
@@ -1,5 +1,7 @@
 package cn.nukkit.block;
 
+import cn.nukkit.blockentity.BlockEntityType;
+import cn.nukkit.blockentity.Furnace;
 import cn.nukkit.utils.Identifier;
 
 /**
@@ -8,8 +10,8 @@ import cn.nukkit.utils.Identifier;
  */
 public class BlockFurnace extends BlockFurnaceBurning {
 
-    public BlockFurnace(Identifier id) {
-        super(id);
+    protected BlockFurnace(Identifier id, BlockEntityType<? extends Furnace> furnace) {
+        super(id, furnace);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockFurnaceBurning.java
+++ b/src/main/java/cn/nukkit/block/BlockFurnaceBurning.java
@@ -1,6 +1,7 @@
 package cn.nukkit.block;
 
 import cn.nukkit.blockentity.BlockEntity;
+import cn.nukkit.blockentity.BlockEntityType;
 import cn.nukkit.blockentity.BlockEntityTypes;
 import cn.nukkit.blockentity.Furnace;
 import cn.nukkit.inventory.ContainerInventory;
@@ -56,7 +57,7 @@ public class BlockFurnaceBurning extends BlockSolid implements Faceable {
         this.setMeta(faces[player != null ? player.getDirection().getHorizontalIndex() : 0]);
         this.getLevel().setBlock(block.getPosition(), this, true, true);
 
-        Furnace furnace = BlockEntityRegistry.get().newEntity(BlockEntityTypes.FURNACE, this.getChunk(), this.getPosition());
+        Furnace furnace = BlockEntityRegistry.get().newEntity(getEntityType(), this.getChunk(), this.getPosition());
         furnace.loadAdditionalData(item.getTag());
         if (item.hasCustomName()) {
             furnace.setCustomName(item.getCustomName());
@@ -79,7 +80,7 @@ public class BlockFurnaceBurning extends BlockSolid implements Faceable {
             if (blockEntity instanceof Furnace) {
                 furnace = (Furnace) blockEntity;
             } else {
-                furnace = BlockEntityRegistry.get().newEntity(BlockEntityTypes.FURNACE, this.getChunk(), this.getPosition());
+                furnace = BlockEntityRegistry.get().newEntity(getEntityType(), this.getChunk(), this.getPosition());
             }
 
             player.addWindow(furnace.getInventory());
@@ -127,5 +128,15 @@ public class BlockFurnaceBurning extends BlockSolid implements Faceable {
     @Override
     public BlockFace getBlockFace() {
         return BlockFace.fromHorizontalIndex(this.getMeta() & 0x7);
+    }
+
+    protected BlockEntityType<? extends Furnace> getEntityType() {
+        if (getId() == BlockIds.BLAST_FURNACE || getId() == BlockIds.LIT_BLAST_FURNACE) {
+            return BlockEntityTypes.BLAST_FURNACE;
+        } else if (getId() == BlockIds.SMOKER || getId() == BlockIds.LIT_SMOKER) {
+            return BlockEntityTypes.SMOKER;
+        } else {
+            return BlockEntityTypes.FURNACE;
+        }
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockFurnaceBurning.java
+++ b/src/main/java/cn/nukkit/block/BlockFurnaceBurning.java
@@ -21,9 +21,15 @@ import static cn.nukkit.block.BlockIds.AIR;
  * Nukkit Project
  */
 public class BlockFurnaceBurning extends BlockSolid implements Faceable {
+    private BlockEntityType<? extends Furnace> furnaceEntity;
 
-    public BlockFurnaceBurning(Identifier id) {
+    protected BlockFurnaceBurning(Identifier id, BlockEntityType<? extends Furnace> entity) {
         super(id);
+        this.furnaceEntity = entity;
+    }
+
+    public static BlockFactory factory (BlockEntityType<? extends Furnace> furnaceEntity) {
+        return id -> new BlockFurnaceBurning(id, furnaceEntity);
     }
 
     @Override
@@ -57,7 +63,7 @@ public class BlockFurnaceBurning extends BlockSolid implements Faceable {
         this.setMeta(faces[player != null ? player.getDirection().getHorizontalIndex() : 0]);
         this.getLevel().setBlock(block.getPosition(), this, true, true);
 
-        Furnace furnace = BlockEntityRegistry.get().newEntity(getEntityType(), this.getChunk(), this.getPosition());
+        Furnace furnace = BlockEntityRegistry.get().newEntity(furnaceEntity, this.getChunk(), this.getPosition());
         furnace.loadAdditionalData(item.getTag());
         if (item.hasCustomName()) {
             furnace.setCustomName(item.getCustomName());
@@ -80,7 +86,7 @@ public class BlockFurnaceBurning extends BlockSolid implements Faceable {
             if (blockEntity instanceof Furnace) {
                 furnace = (Furnace) blockEntity;
             } else {
-                furnace = BlockEntityRegistry.get().newEntity(getEntityType(), this.getChunk(), this.getPosition());
+                furnace = BlockEntityRegistry.get().newEntity(furnaceEntity, this.getChunk(), this.getPosition());
             }
 
             player.addWindow(furnace.getInventory());
@@ -130,13 +136,4 @@ public class BlockFurnaceBurning extends BlockSolid implements Faceable {
         return BlockFace.fromHorizontalIndex(this.getMeta() & 0x7);
     }
 
-    protected BlockEntityType<? extends Furnace> getEntityType() {
-        if (getId() == BlockIds.BLAST_FURNACE || getId() == BlockIds.LIT_BLAST_FURNACE) {
-            return BlockEntityTypes.BLAST_FURNACE;
-        } else if (getId() == BlockIds.SMOKER || getId() == BlockIds.LIT_SMOKER) {
-            return BlockEntityTypes.SMOKER;
-        } else {
-            return BlockEntityTypes.FURNACE;
-        }
-    }
 }

--- a/src/main/java/cn/nukkit/blockentity/impl/BeaconBlockEntity.java
+++ b/src/main/java/cn/nukkit/blockentity/impl/BeaconBlockEntity.java
@@ -33,13 +33,6 @@ public class BeaconBlockEntity extends BaseBlockEntity implements Beacon {
     }
 
     @Override
-    protected void init() {
-        scheduleUpdate();
-
-        super.init();
-    }
-
-    @Override
     public void loadAdditionalData(CompoundTag tag) {
         super.loadAdditionalData(tag);
 
@@ -49,6 +42,7 @@ public class BeaconBlockEntity extends BaseBlockEntity implements Beacon {
 
     @Override
     public void saveAdditionalData(CompoundTagBuilder tag) {
+        super.saveAdditionalData(tag);
         tag.intTag("primary", this.getPrimaryEffect());
         tag.intTag("secondary", this.getSecondaryEffect());
     }
@@ -107,9 +101,9 @@ public class BeaconBlockEntity extends BaseBlockEntity implements Beacon {
 
                     //If secondary is selected as the primary too, apply 2 amplification
                     if (getSecondaryEffect() == getPrimaryEffect()) {
-                        e.setAmplifier(2);
-                    } else {
                         e.setAmplifier(1);
+                    } else {
+                        e.setAmplifier(0);
                     }
 
                     //Hide particles
@@ -128,7 +122,7 @@ public class BeaconBlockEntity extends BaseBlockEntity implements Beacon {
                     e.setDuration(duration * 20);
 
                     //Regen I
-                    e.setAmplifier(1);
+                    e.setAmplifier(0);
 
                     //Hide particles
                     e.setVisible(false);
@@ -158,7 +152,7 @@ public class BeaconBlockEntity extends BaseBlockEntity implements Beacon {
     }
 
     private int calculatePowerLevel() {
-        int tileX = this.getPosition().getZ();
+        int tileX = this.getPosition().getX();
         int tileY = this.getPosition().getY();
         int tileZ = this.getPosition().getZ();
 
@@ -215,6 +209,12 @@ public class BeaconBlockEntity extends BaseBlockEntity implements Beacon {
         BeaconInventory inv = (BeaconInventory) player.getWindowById(ContainerIds.BEACON);
 
         inv.clear(0);
+        this.scheduleUpdate();
+        return true;
+    }
+
+    @Override
+    public boolean isSpawnable() {
         return true;
     }
 }

--- a/src/main/java/cn/nukkit/blockentity/impl/BlastFurnaceBlockEntity.java
+++ b/src/main/java/cn/nukkit/blockentity/impl/BlastFurnaceBlockEntity.java
@@ -12,7 +12,7 @@ import com.nukkitx.math.vector.Vector3i;
 public class BlastFurnaceBlockEntity extends FurnaceBlockEntity implements BlastFurnace {
 
     public BlastFurnaceBlockEntity(BlockEntityType<?> type, Chunk chunk, Vector3i position) {
-        super(type, chunk, position, InventoryType.SMOKER);
+        super(type, chunk, position, InventoryType.BLAST_FURNACE);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/blockentity/impl/EnchantingTableBlockEntity.java
+++ b/src/main/java/cn/nukkit/blockentity/impl/EnchantingTableBlockEntity.java
@@ -21,8 +21,4 @@ public class EnchantingTableBlockEntity extends BaseBlockEntity implements Encha
         return getBlock().getId() == BlockIds.ENCHANTING_TABLE;
     }
 
-    @Override
-    public boolean isSpawnable() {
-        return true;
-    }
 }

--- a/src/main/java/cn/nukkit/blockentity/impl/FurnaceBlockEntity.java
+++ b/src/main/java/cn/nukkit/blockentity/impl/FurnaceBlockEntity.java
@@ -2,7 +2,8 @@ package cn.nukkit.blockentity.impl;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockIds;
-import cn.nukkit.blockentity.*;
+import cn.nukkit.blockentity.BlockEntityType;
+import cn.nukkit.blockentity.Furnace;
 import cn.nukkit.event.inventory.FurnaceBurnEvent;
 import cn.nukkit.event.inventory.FurnaceSmeltEvent;
 import cn.nukkit.inventory.FurnaceInventory;
@@ -29,7 +30,7 @@ import static cn.nukkit.item.ItemIds.BUCKET;
 /**
  * @author MagicDroidX
  */
-public class FurnaceBlockEntity extends BaseBlockEntity implements Furnace, BlastFurnace, Smoker {
+public class FurnaceBlockEntity extends BaseBlockEntity implements Furnace {
 
     protected final FurnaceInventory inventory;
     protected short burnTime = 0;

--- a/src/main/java/cn/nukkit/blockentity/impl/FurnaceBlockEntity.java
+++ b/src/main/java/cn/nukkit/blockentity/impl/FurnaceBlockEntity.java
@@ -78,12 +78,6 @@ public class FurnaceBlockEntity extends BaseBlockEntity implements Furnace {
         tag.shortTag("CookTime", cookTime);
         tag.shortTag("BurnTime", burnTime);
         tag.shortTag("MaxTime", maxTime);
-    }
-
-    @Override
-    protected void saveClientData(CompoundTagBuilder tag) {
-        super.saveClientData(tag);
-
         List<CompoundTag> items = new ArrayList<>();
         for (Map.Entry<Integer, Item> entry : this.inventory.getContents().entrySet()) {
             items.add(ItemUtils.serializeItem(entry.getValue(), entry.getKey()));

--- a/src/main/java/cn/nukkit/blockentity/impl/FurnaceBlockEntity.java
+++ b/src/main/java/cn/nukkit/blockentity/impl/FurnaceBlockEntity.java
@@ -2,8 +2,7 @@ package cn.nukkit.blockentity.impl;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockIds;
-import cn.nukkit.blockentity.BlockEntityType;
-import cn.nukkit.blockentity.Furnace;
+import cn.nukkit.blockentity.*;
 import cn.nukkit.event.inventory.FurnaceBurnEvent;
 import cn.nukkit.event.inventory.FurnaceSmeltEvent;
 import cn.nukkit.inventory.FurnaceInventory;
@@ -30,11 +29,10 @@ import static cn.nukkit.item.ItemIds.BUCKET;
 /**
  * @author MagicDroidX
  */
-public class FurnaceBlockEntity extends BaseBlockEntity implements Furnace {
+public class FurnaceBlockEntity extends BaseBlockEntity implements Furnace, BlastFurnace, Smoker {
 
     protected final FurnaceInventory inventory;
     protected short burnTime = 0;
-    protected short burnDuration = 0;
     protected short cookTime = 0;
     protected short maxTime = 0;
 
@@ -44,17 +42,7 @@ public class FurnaceBlockEntity extends BaseBlockEntity implements Furnace {
     }
 
     public FurnaceBlockEntity(BlockEntityType<?> type, Chunk chunk, Vector3i position) {
-        super(type, chunk, position);
-        InventoryType invType;
-        Block furnace = getBlock();
-        if (furnace.getId() == BLAST_FURNACE || furnace.getId() == LIT_BLAST_FURNACE) {
-            invType = InventoryType.BLAST_FURNACE;
-        } else if (furnace.getId() == SMOKER || furnace.getId() == LIT_SMOKER) {
-            invType = InventoryType.SMOKER;
-        } else {
-            invType = InventoryType.FURNACE;
-        }
-        this.inventory = new FurnaceInventory(this, invType);
+        this(type, chunk, position, InventoryType.FURNACE);
     }
 
     @Override
@@ -95,10 +83,6 @@ public class FurnaceBlockEntity extends BaseBlockEntity implements Furnace {
         }
     }
 
-    public float getBurnRate() {
-        return 1.0f;
-    }
-
     @Override
     public void onBreak() {
         for (Item content : inventory.getContents().values()) {
@@ -109,12 +93,16 @@ public class FurnaceBlockEntity extends BaseBlockEntity implements Furnace {
     @Override
     public boolean isValid() {
         Identifier blockId = getBlock().getId();
-        return blockId == BlockIds.FURNACE || blockId == BlockIds.LIT_FURNACE;
+        return blockId == FURNACE || blockId == LIT_FURNACE;
     }
 
     @Override
     public FurnaceInventory getInventory() {
         return inventory;
+    }
+
+    protected float getBurnRate() {
+        return 1.0f;
     }
 
     protected void checkFuel(Item fuel) {
@@ -237,11 +225,11 @@ public class FurnaceBlockEntity extends BaseBlockEntity implements Furnace {
     }
 
     protected void extinguishFurnace() {
-        this.getLevel().setBlock(this.getPosition(), Block.get(BlockIds.FURNACE, this.getBlock().getMeta()), true);
+        this.getLevel().setBlock(this.getPosition(), Block.get(FURNACE, this.getBlock().getMeta()), true);
     }
 
     protected void lightFurnace() {
-        this.getLevel().setBlock(this.getPosition(), Block.get(BlockIds.LIT_FURNACE, this.getBlock().getMeta()), true);
+        this.getLevel().setBlock(this.getPosition(), Block.get(LIT_FURNACE, this.getBlock().getMeta()), true);
     }
 
     public int getBurnTime() {

--- a/src/main/java/cn/nukkit/blockentity/impl/SmokerBlockEntity.java
+++ b/src/main/java/cn/nukkit/blockentity/impl/SmokerBlockEntity.java
@@ -2,7 +2,9 @@ package cn.nukkit.blockentity.impl;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockIds;
+import cn.nukkit.blockentity.BlockEntityFactory;
 import cn.nukkit.blockentity.BlockEntityType;
+import cn.nukkit.blockentity.Furnace;
 import cn.nukkit.blockentity.Smoker;
 import cn.nukkit.inventory.InventoryType;
 import cn.nukkit.level.chunk.Chunk;

--- a/src/main/java/cn/nukkit/inventory/BarrelInventory.java
+++ b/src/main/java/cn/nukkit/inventory/BarrelInventory.java
@@ -31,8 +31,7 @@ public class BarrelInventory extends ContainerInventory {
                     BlockBarrel blockBarrel = (BlockBarrel) block;
                     if (!blockBarrel.isOpen()) {
                         blockBarrel.setOpen(true);
-                        level.setBlock(blockBarrel.getPosition(), blockBarrel, true, true);
-                        level.addLevelSoundEvent(this.getHolder().getPosition(), SoundEvent.CHEST_OPEN);
+                        level.addLevelSoundEvent(this.getHolder().getPosition(), SoundEvent.BARREL_OPEN);
                     }
                 }
             }
@@ -52,8 +51,7 @@ public class BarrelInventory extends ContainerInventory {
                     BlockBarrel blockBarrel = (BlockBarrel) block;
                     if (blockBarrel.isOpen()) {
                         blockBarrel.setOpen(false);
-                        level.setBlock(blockBarrel.getPosition(), blockBarrel, true, true);
-                        level.addLevelSoundEvent(this.getHolder().getPosition(), SoundEvent.CHEST_CLOSED);
+                        level.addLevelSoundEvent(this.getHolder().getPosition(), SoundEvent.BARREL_CLOSE);
                     }
                 }
             }

--- a/src/main/java/cn/nukkit/inventory/ChestInventory.java
+++ b/src/main/java/cn/nukkit/inventory/ChestInventory.java
@@ -31,7 +31,7 @@ public class ChestInventory extends ContainerInventory {
             BlockEventPacket packet = new BlockEventPacket();
             packet.setBlockPosition(this.getHolder().getPosition());
             packet.setEventType(1);
-            packet.setEventData(2);
+            packet.setEventData(1);
 
             Level level = this.getHolder().getLevel();
             if (level != null) {

--- a/src/main/java/cn/nukkit/inventory/ContainerInventory.java
+++ b/src/main/java/cn/nukkit/inventory/ContainerInventory.java
@@ -37,7 +37,7 @@ public abstract class ContainerInventory extends BaseInventory {
     public void onOpen(Player who) {
         super.onOpen(who);
         ContainerOpenPacket packet = new ContainerOpenPacket();
-        packet.setWindowId((byte) who.getWindowId(this));
+        packet.setWindowId(who.getWindowId(this));
         packet.setType((byte) this.getType().getNetworkType());
         InventoryHolder holder = this.getHolder();
         if (holder instanceof BlockEntity) {
@@ -54,7 +54,7 @@ public abstract class ContainerInventory extends BaseInventory {
     @Override
     public void onClose(Player who) {
         ContainerClosePacket packet = new ContainerClosePacket();
-        packet.setWindowId((byte) who.getWindowId(this));
+        packet.setWindowId(who.getWindowId(this));
         who.sendPacket(packet);
         super.onClose(who);
     }

--- a/src/main/java/cn/nukkit/inventory/DoubleChestInventory.java
+++ b/src/main/java/cn/nukkit/inventory/DoubleChestInventory.java
@@ -119,11 +119,11 @@ public class DoubleChestInventory extends ContainerInventory implements Inventor
             BlockEventPacket packet = new BlockEventPacket();
             packet.setBlockPosition(this.left.getHolder().getPosition());
             packet.setEventType(1);
-            packet.setEventData(2);
+            packet.setEventData(1);
             Level level = this.left.getHolder().getLevel();
             if (level != null) {
                 level.addLevelSoundEvent(this.left.getHolder().getPosition(), SoundEvent.CHEST_OPEN);
-                level.addChunkPacket(left.getHolder().getPosition(), packet);
+                level.addChunkPacket(this.left.getHolder().getPosition(), packet);
             }
         }
     }

--- a/src/main/java/cn/nukkit/inventory/InventoryType.java
+++ b/src/main/java/cn/nukkit/inventory/InventoryType.java
@@ -14,7 +14,7 @@ public enum InventoryType {
     WORKBENCH(10, "Crafting", 1), //9 CRAFTING slots, 1 RESULT
     BREWING_STAND(5, "Brewing", 4), //1 INPUT, 3 POTION, 1 fuel
     ANVIL(3, "Anvil", 5), //2 INPUT, 1 OUTPUT
-    ENCHANT_TABLE(2, "Enchant", 3), //1 INPUT/OUTPUT, 1 LAPIS
+    ENCHANT_TABLE(2, "Enchantment Table", 3), //1 INPUT/OUTPUT, 1 LAPIS
     DISPENSER(9, "Dispenser", 6), //9 CONTAINER
     DROPPER(9, "Dropper", 7), //9 CONTAINER
     HOPPER(5, "Hopper", 8), //5 CONTAINER

--- a/src/main/java/cn/nukkit/inventory/PlayerEnderChestInventory.java
+++ b/src/main/java/cn/nukkit/inventory/PlayerEnderChestInventory.java
@@ -28,7 +28,7 @@ public class PlayerEnderChestInventory extends BaseInventory {
         }
         super.onOpen(who);
         ContainerOpenPacket containerOpenPacket = new ContainerOpenPacket();
-        containerOpenPacket.setWindowId((byte) who.getWindowId(this));
+        containerOpenPacket.setWindowId(who.getWindowId(this));
         containerOpenPacket.setType((byte) this.getType().getNetworkType());
         BlockEnderChest chest = who.getViewingEnderChest();
         if (chest != null) {
@@ -45,7 +45,7 @@ public class PlayerEnderChestInventory extends BaseInventory {
             BlockEventPacket blockEventPacket = new BlockEventPacket();
             blockEventPacket.setBlockPosition(chest.getPosition());
             blockEventPacket.setEventType(1);
-            blockEventPacket.setEventData(2);
+            blockEventPacket.setEventData(1);
 
             Level level = this.getHolder().getLevel();
             if (level != null) {
@@ -58,7 +58,7 @@ public class PlayerEnderChestInventory extends BaseInventory {
     @Override
     public void onClose(Player who) {
         ContainerClosePacket containerClosePacket = new ContainerClosePacket();
-        containerClosePacket.setWindowId((byte) who.getWindowId(this));
+        containerClosePacket.setWindowId(who.getWindowId(this));
         who.sendPacket(containerClosePacket);
         super.onClose(who);
 

--- a/src/main/java/cn/nukkit/level/ChunkManager.java
+++ b/src/main/java/cn/nukkit/level/ChunkManager.java
@@ -68,6 +68,14 @@ public interface ChunkManager {
         this.setBlockDataAt(x, y, z, 0, data);
     }
 
+    default void setBlockDataAt(Vector3i pos, int data) {
+        this.setBlockDataAt(pos, 0, data);
+    }
+
+    default void setBlockDataAt(Vector3i pos, int layer, int data) {
+        this.setBlockDataAt(pos.getX(), pos.getY(), pos.getZ(), layer, data);
+    }
+
     void setBlockDataAt(int x, int y, int z, int layer, int data);
 
     default Block getBlockAt(int x, int y, int z) {

--- a/src/main/java/cn/nukkit/level/chunk/UnsafeChunk.java
+++ b/src/main/java/cn/nukkit/level/chunk/UnsafeChunk.java
@@ -236,8 +236,7 @@ public final class UnsafeChunk implements IChunk, Closeable {
         checkBounds(x, y, z);
         ChunkSection section = this.getSection(y >> 4);
         if (section == null) {
-            //setting meta on non-existing block?
-            return;
+            throw new IllegalStateException("Setting BlockData on null section");
         }
 
         section.setBlockData(x, y & 0xf, z, layer, data);

--- a/src/main/java/cn/nukkit/level/chunk/UnsafeChunk.java
+++ b/src/main/java/cn/nukkit/level/chunk/UnsafeChunk.java
@@ -236,11 +236,8 @@ public final class UnsafeChunk implements IChunk, Closeable {
         checkBounds(x, y, z);
         ChunkSection section = this.getSection(y >> 4);
         if (section == null) {
-            if (data == 0) {
-                // Setting air in an empty section.
-                return;
-            }
-            section = this.getOrCreateSection(y >> 4);
+            //setting meta on non-existing block?
+            return;
         }
 
         section.setBlockData(x, y & 0xf, z, layer, data);

--- a/src/main/java/cn/nukkit/level/provider/leveldb/serializer/BlockEntitySerializer.java
+++ b/src/main/java/cn/nukkit/level/provider/leveldb/serializer/BlockEntitySerializer.java
@@ -82,7 +82,7 @@ public class BlockEntitySerializer {
                         dirty = true;
                         continue;
                     }
-                    Vector3i position = Vector3i.from(tag.getInt("x"), tag.getInt("y"), tag.getInt("y"));
+                    Vector3i position = Vector3i.from(tag.getInt("x"), tag.getInt("y"), tag.getInt("z"));
                     if ((position.getX() >> 4) != chunk.getX() || ((position.getZ() >> 4) != chunk.getZ())) {
                         dirty = true;
                         continue;
@@ -92,7 +92,9 @@ public class BlockEntitySerializer {
                     BlockEntity blockEntity = REGISTRY.newEntity(type, chunk, position);
                     if (blockEntity == null) {
                         dirty = true;
+                        continue;
                     }
+                    blockEntity.loadAdditionalData(tag);
                 }
             }
             return dirty;

--- a/src/main/java/cn/nukkit/level/provider/leveldb/serializer/EntitySerializer.java
+++ b/src/main/java/cn/nukkit/level/provider/leveldb/serializer/EntitySerializer.java
@@ -111,7 +111,10 @@ public class EntitySerializer {
                 EntityRegistry registry = EntityRegistry.get();
                 EntityType<?> type = registry.getEntityType(identifier);
                 try {
-                    registry.newEntity(type, location);
+                    Entity entity = registry.newEntity(type, location);
+                    if (entity != null) {
+                        entity.loadAdditionalData(entityTag);
+                    }
                 } catch (RegistryException e) {
                     dirty = true;
                 }

--- a/src/main/java/cn/nukkit/player/Player.java
+++ b/src/main/java/cn/nukkit/player/Player.java
@@ -2064,7 +2064,7 @@ public class Player extends Human implements CommandSender, InventoryHolder, Chu
                     }
 
                     MovePlayerPacket movePlayerPacket = (MovePlayerPacket) packet;
-                    Vector3f newPos = Vector3f.from(movePlayerPacket.getPosition().sub(0, this.getEyeHeight(), 0));
+                    Vector3f newPos = movePlayerPacket.getPosition().sub(0, this.getEyeHeight(), 0);
                     Vector3f currentPos = this.getPosition();
 
                     float yaw = movePlayerPacket.getRotation().getY() % 360;
@@ -3595,7 +3595,7 @@ public class Player extends Human implements CommandSender, InventoryHolder, Chu
         MovePlayerPacket packet = new MovePlayerPacket();
         packet.setRuntimeEntityId(this.getRuntimeId());
         packet.setPosition(pos.add(0, getEyeHeight(), 0));
-        packet.setRotation(com.nukkitx.math.vector.Vector3f.from(pitch, yaw, yaw));
+        packet.setRotation(Vector3f.from(pitch, yaw, yaw));
         packet.setMode(mode);
         if (mode == MovePlayerPacket.Mode.TELEPORT) {
             packet.setTeleportationCause(MovePlayerPacket.TeleportationCause.BEHAVIOR);

--- a/src/main/java/cn/nukkit/player/Player.java
+++ b/src/main/java/cn/nukkit/player/Player.java
@@ -2067,8 +2067,8 @@ public class Player extends Human implements CommandSender, InventoryHolder, Chu
                     Vector3f newPos = Vector3f.from(movePlayerPacket.getPosition().sub(0, this.getEyeHeight(), 0));
                     Vector3f currentPos = this.getPosition();
 
-                    float yaw = movePlayerPacket.getRotation().getX() % 360;
-                    float pitch = movePlayerPacket.getRotation().getY() % 360;
+                    float yaw = movePlayerPacket.getRotation().getY() % 360;
+                    float pitch = movePlayerPacket.getRotation().getX() % 360;
 
                     if (yaw < 0) {
                         yaw += 360;
@@ -3595,7 +3595,7 @@ public class Player extends Human implements CommandSender, InventoryHolder, Chu
         MovePlayerPacket packet = new MovePlayerPacket();
         packet.setRuntimeEntityId(this.getRuntimeId());
         packet.setPosition(pos.add(0, getEyeHeight(), 0));
-        packet.setRotation(com.nukkitx.math.vector.Vector3f.from(yaw, pitch, yaw));
+        packet.setRotation(com.nukkitx.math.vector.Vector3f.from(pitch, yaw, yaw));
         packet.setMode(mode);
         if (mode == MovePlayerPacket.Mode.TELEPORT) {
             packet.setTeleportationCause(MovePlayerPacket.TeleportationCause.BEHAVIOR);

--- a/src/main/java/cn/nukkit/registry/BlockEntityRegistry.java
+++ b/src/main/java/cn/nukkit/registry/BlockEntityRegistry.java
@@ -1,9 +1,12 @@
 package cn.nukkit.registry;
 
+import cn.nukkit.block.BlockIds;
+import cn.nukkit.blockentity.BlastFurnace;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.blockentity.BlockEntityFactory;
 import cn.nukkit.blockentity.BlockEntityType;
 import cn.nukkit.blockentity.impl.*;
+import cn.nukkit.inventory.InventoryType;
 import cn.nukkit.level.chunk.Chunk;
 import cn.nukkit.plugin.Plugin;
 import com.google.common.collect.BiMap;
@@ -31,7 +34,7 @@ public class BlockEntityRegistry implements Registry {
         return INSTANCE;
     }
 
-    private <T extends BlockEntity> void registerVanilla(BlockEntityType<T> type, BlockEntityFactory<T> factory, String persistentId) {
+    private <T extends BlockEntity> void registerVanilla(BlockEntityType<T> type, BlockEntityFactory<? extends T> factory, String persistentId) {
         checkNotNull(type, "type");
         checkNotNull(factory, "factory");
         checkNotNull(persistentId, "persistentId");

--- a/src/main/java/cn/nukkit/registry/BlockRegistry.java
+++ b/src/main/java/cn/nukkit/registry/BlockRegistry.java
@@ -1,6 +1,9 @@
 package cn.nukkit.registry;
 
 import cn.nukkit.block.*;
+import cn.nukkit.blockentity.BlockEntity;
+import cn.nukkit.blockentity.BlockEntityType;
+import cn.nukkit.blockentity.BlockEntityTypes;
 import cn.nukkit.item.ItemIds;
 import cn.nukkit.utils.BlockColor;
 import cn.nukkit.utils.Identifier;
@@ -313,8 +316,8 @@ public class BlockRegistry implements Registry {
         this.factoryMap.put(CRAFTING_TABLE, BlockCraftingTable::new); //58
         this.factoryMap.put(WHEAT, BlockWheat::new); //59
         this.factoryMap.put(FARMLAND, BlockFarmland::new); //60
-        this.factoryMap.put(FURNACE, BlockFurnace::new); //61
-        this.factoryMap.put(LIT_FURNACE, BlockFurnaceBurning::new); //62
+        this.factoryMap.put(FURNACE, BlockFurnace.factory(BlockEntityTypes.FURNACE)); //61
+        this.factoryMap.put(LIT_FURNACE, BlockFurnaceBurning.factory(BlockEntityTypes.FURNACE)); //62
         this.factoryMap.put(STANDING_SIGN, BlockSignPost.factory(WALL_SIGN, ItemIds.SIGN)); //63
         this.factoryMap.put(WOODEN_DOOR, BlockDoorWood::new); //64
         this.factoryMap.put(LADDER, BlockLadder::new); //65
@@ -588,10 +591,10 @@ public class BlockRegistry implements Registry {
         this.factoryMap.put(DARK_OAK_WALL_SIGN, BlockWallSign.factory(DARK_OAK_STANDING_SIGN, ItemIds.DARK_OAK_SIGN)); //447
         this.factoryMap.put(LECTERN, BlockLectern::new); //448
         //449: grindstone
-        this.factoryMap.put(BLAST_FURNACE, BlockFurnace::new); // 450
+        this.factoryMap.put(BLAST_FURNACE, BlockFurnace.factory(BlockEntityTypes.BLAST_FURNACE)); // 450
         //451: stonecutter_block
-        this.factoryMap.put(SMOKER, BlockFurnace::new); //452
-        this.factoryMap.put(LIT_SMOKER, BlockFurnaceBurning::new); //453
+        this.factoryMap.put(SMOKER, BlockFurnace.factory(BlockEntityTypes.SMOKER)); //452
+        this.factoryMap.put(LIT_SMOKER, BlockFurnaceBurning.factory(BlockEntityTypes.SMOKER)); //453
         //454: cartography_table
         //455: fletching_table
         //456: smithing_table
@@ -605,7 +608,7 @@ public class BlockRegistry implements Registry {
         //464: jigsaw
         this.factoryMap.put(WOOD, BlockWood::new); //465
         //466: composter
-        this.factoryMap.put(LIT_BLAST_FURNACE, BlockFurnaceBurning::new); //467
+        this.factoryMap.put(LIT_BLAST_FURNACE, BlockFurnaceBurning.factory(BlockEntityTypes.BLAST_FURNACE)); //467
         this.factoryMap.put(LIGHT_BLOCK, BlockLight::new); //468
         //469: wither_rose
         //470: stickypistonarmcollision

--- a/src/main/java/cn/nukkit/utils/Identifier.java
+++ b/src/main/java/cn/nukkit/utils/Identifier.java
@@ -2,8 +2,8 @@ package cn.nukkit.utils;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import net.daporkchop.lib.common.cache.Cache;
-import net.daporkchop.lib.common.cache.ThreadCache;
+import net.daporkchop.lib.common.ref.Ref;
+import net.daporkchop.lib.common.ref.ThreadRef;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,7 +20,7 @@ public final class Identifier implements Comparable<Identifier> {
     public static final Identifier EMPTY = new Identifier("", "", "" + NAMESPACE_SEPARATOR);
 
     private static final Pattern PATTERN = Pattern.compile("^(?>minecraft:)?(?>([a-z0-9_]*)" + NAMESPACE_SEPARATOR + ")?([a-zA-Z0-9_]*)$");
-    private static final Cache<Matcher> MATCHER_CACHE = ThreadCache.soft(() -> PATTERN.matcher(""));
+    private static final Ref<Matcher> MATCHER_CACHE = ThreadRef.soft(() -> PATTERN.matcher(""));
 
     private static final Lock READ_LOCK;
     private static final Lock WRITE_LOCK;


### PR DESCRIPTION
Fixes some problems created with BlockEntities from the Protocol Library update. 

- added `loadAdditionalData` to `BlockEntitySerializer` and `EntitySerializer` loaders
- fixed typo of `BlockEntitySerializer` loading `position` `z` value as `y` value
- the `yaw` and `pitch` were being read incorrectly from `MovePlayerPacket`, causing placement of entities that have directions to be incorrect
- chunk `setBlockData()` was checking if `data = 0` as if it was `BlockId == AIR`, when we shouldn't be setting any block data in a null section
- Add Convenience methods for `setBlockDataAt` which accepts `Vector3i` position
- Allows beds to be placed on slabs
- Chest Changes:
  - Changed to match Vanilla NBT saving (paired x/z only saves with primary that has pairlead set to true)
  - updated NBT saving to use `saveClientData` to send proper spawnable NBT to client
  - updated `BlockEventPacket` to use `1` for the `eventData` to open a chest, to match Vanilla (verified via proxypass on vanilla BDS)
    - [ ] TODO: does not work for double chest?? need to figure out why
- Barrel 
   - update SoundEvent to use `BARREL_OPEN/BARREL_CLOSED` sounds
      - required bump of protocol-library version
   - [ ] setting open bit on the barrel block is not displaying as open (block palette goof up?)
- Beacon fixes:
   - Don't need to override `init()` to call scheduleUpdate() since one update is always triggered
   - `setAmplifier` starts at 0 for level 1, 1 for level 2, etc.
   - fix X position check in `calculatePowerLevel`
   - need to have spawnable to trigger beam on load and have effects change from player sending update packet
- Furnace fixes:
  - Update `FurnaceBlockEntity` to use correct `InventoryType` when using standard constructor
  - Update `BlockFurnaceBurning` to create correct block entity based on the furnace ID
  - remove usless `burnDuration` variable (burnTime does the same thing)
- Enchantment Table:
  - Updated `defaultTitle` in `InventoryType` to match vanilla of "Enchantment Table"
  - removed `isSpawnable` since no NBT data needs to be sent to the client
- [ ] Cauldron is a mess

- [ ] Check remaining block entities