### PR TITLE
[2.0] Fix IllegalArgumentException with y > 15

### DIFF
--- a/src/main/java/cn/nukkit/level/chunk/UnsafeChunk.java
+++ b/src/main/java/cn/nukkit/level/chunk/UnsafeChunk.java
@@ -269,7 +269,7 @@ public final class UnsafeChunk implements IChunk, Closeable {
     public byte getSkyLight(int x, int y, int z) {
         checkBounds(x, y, z);
         ChunkSection section = this.getSection(y >> 4);
-        return section == null ? 0 : section.getSkyLight(x, y, z);
+        return section == null ? 0 : section.getSkyLight(x, y & 0xf, z);
     }
 
     @Override


### PR DESCRIPTION
Example call:
```java
Level level = getLevel();
int light = level.getFullLight(new Vector3i(0, 76, 0));
```

Exception:
```java
java.lang.IllegalArgumentException: y (76) is not between 0 and 15
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:168)
	at cn.nukkit.level.chunk.ChunkSection.checkBounds(ChunkSection.java:53)
	at cn.nukkit.level.chunk.ChunkSection.getSkyLight(ChunkSection.java:110)
	at cn.nukkit.level.chunk.UnsafeChunk.getSkyLight(UnsafeChunk.java:272)
	at cn.nukkit.level.chunk.Chunk.getSkyLight(Chunk.java:253)
	at cn.nukkit.level.Level.getFullLight(Level.java:1275)
        at <caller>
```