### PR TITLE
[2.0] Remove unused parameter

### DIFF
--- a/src/main/java/cn/nukkit/permission/PermissionAttachment.java
+++ b/src/main/java/cn/nukkit/permission/PermissionAttachment.java
@@ -81,11 +81,11 @@ public class PermissionAttachment {
         this.permissible.recalculatePermissions();
     }
 
-    public void unsetPermission(Permission permission, boolean value) {
-        this.unsetPermission(permission.getName(), value);
+    public void unsetPermission(Permission permission) {
+        this.unsetPermission(permission.getName());
     }
 
-    public void unsetPermission(String name, boolean value) {
+    public void unsetPermission(String name) {
         if (this.permissions.containsKey(name)) {
             this.permissions.remove(name);
             this.permissible.recalculatePermissions();


### PR DESCRIPTION
### Introduction
This PR simply removes the unused parameter from `PermissionAttachment.unsetPermission()`. This is technically a breaking change as any plugin using this method will have to provide a second parameter, however this should be fine as the target branch is already breaking enough.