### PR TITLE
[2.0] create static method for sending BlockEventPackets 

### DIFF
--- a/src/main/java/cn/nukkit/inventory/BarrelInventory.java
+++ b/src/main/java/cn/nukkit/inventory/BarrelInventory.java
@@ -32,6 +32,7 @@ public class BarrelInventory extends ContainerInventory {
                     if (!blockBarrel.isOpen()) {
                         blockBarrel.setOpen(true);
                         level.addLevelSoundEvent(this.getHolder().getPosition(), SoundEvent.BARREL_OPEN);
+                        ContainerInventory.sendBlockEventPacket(this.getHolder(), 1);
                     }
                 }
             }
@@ -52,6 +53,7 @@ public class BarrelInventory extends ContainerInventory {
                     if (blockBarrel.isOpen()) {
                         blockBarrel.setOpen(false);
                         level.addLevelSoundEvent(this.getHolder().getPosition(), SoundEvent.BARREL_CLOSE);
+                        ContainerInventory.sendBlockEventPacket(this.getHolder(), 0);
                     }
                 }
             }

--- a/src/main/java/cn/nukkit/inventory/ChestInventory.java
+++ b/src/main/java/cn/nukkit/inventory/ChestInventory.java
@@ -4,7 +4,6 @@ import cn.nukkit.blockentity.Chest;
 import cn.nukkit.level.Level;
 import cn.nukkit.player.Player;
 import com.nukkitx.protocol.bedrock.data.SoundEvent;
-import com.nukkitx.protocol.bedrock.packet.BlockEventPacket;
 
 /**
  * author: MagicDroidX
@@ -28,15 +27,10 @@ public class ChestInventory extends ContainerInventory {
         super.onOpen(who);
 
         if (this.getViewers().size() == 1) {
-            BlockEventPacket packet = new BlockEventPacket();
-            packet.setBlockPosition(this.getHolder().getPosition());
-            packet.setEventType(1);
-            packet.setEventData(1);
-
             Level level = this.getHolder().getLevel();
             if (level != null) {
                 level.addLevelSoundEvent(this.getHolder().getPosition(), SoundEvent.CHEST_OPEN);
-                level.addChunkPacket(this.getHolder().getPosition(), packet);
+                ContainerInventory.sendBlockEventPacket(this.getHolder(), 1);
             }
         }
     }
@@ -44,18 +38,12 @@ public class ChestInventory extends ContainerInventory {
     @Override
     public void onClose(Player who) {
         if (this.getViewers().size() == 1) {
-            BlockEventPacket packet = new BlockEventPacket();
-            packet.setBlockPosition(this.getHolder().getPosition());
-            packet.setEventType(1);
-            packet.setEventData(0);
-
             Level level = this.getHolder().getLevel();
             if (level != null) {
                 level.addLevelSoundEvent(this.getHolder().getPosition(), SoundEvent.CHEST_CLOSED);
-                level.addChunkPacket(this.getHolder().getPosition(), packet);
+                ContainerInventory.sendBlockEventPacket(this.getHolder(), 0);
             }
         }
-
         super.onClose(who);
     }
 

--- a/src/main/java/cn/nukkit/inventory/ContainerInventory.java
+++ b/src/main/java/cn/nukkit/inventory/ContainerInventory.java
@@ -5,6 +5,7 @@ import cn.nukkit.item.Item;
 import cn.nukkit.math.NukkitMath;
 import cn.nukkit.player.Player;
 import com.nukkitx.math.vector.Vector3i;
+import com.nukkitx.protocol.bedrock.packet.BlockEventPacket;
 import com.nukkitx.protocol.bedrock.packet.ContainerClosePacket;
 import com.nukkitx.protocol.bedrock.packet.ContainerOpenPacket;
 
@@ -45,7 +46,6 @@ public abstract class ContainerInventory extends BaseInventory {
         } else {
             packet.setBlockPosition(Vector3i.ZERO);
         }
-
         who.sendPacket(packet);
 
         this.sendContents(who);
@@ -78,5 +78,14 @@ public abstract class ContainerInventory extends BaseInventory {
             averageCount = averageCount / (float) inv.getSize();
             return NukkitMath.floorFloat(averageCount * 14) + (itemCount > 0 ? 1 : 0);
         }
+    }
+
+    public static void sendBlockEventPacket(BlockEntity block, int eventData) {
+        if (block.getLevel() == null) return;
+        BlockEventPacket bep = new BlockEventPacket();
+        bep.setBlockPosition(block.getPosition());
+        bep.setEventType(1);
+        bep.setEventData(eventData);
+        block.getLevel().addChunkPacket(block.getPosition(), bep);
     }
 }

--- a/src/main/java/cn/nukkit/inventory/DoubleChestInventory.java
+++ b/src/main/java/cn/nukkit/inventory/DoubleChestInventory.java
@@ -6,7 +6,6 @@ import cn.nukkit.item.Item;
 import cn.nukkit.level.Level;
 import cn.nukkit.player.Player;
 import com.nukkitx.protocol.bedrock.data.SoundEvent;
-import com.nukkitx.protocol.bedrock.packet.BlockEventPacket;
 import com.nukkitx.protocol.bedrock.packet.InventorySlotPacket;
 
 import java.util.HashMap;
@@ -116,14 +115,10 @@ public class DoubleChestInventory extends ContainerInventory implements Inventor
         this.right.viewers.add(who);
 
         if (this.getViewers().size() == 1) {
-            BlockEventPacket packet = new BlockEventPacket();
-            packet.setBlockPosition(this.left.getHolder().getPosition());
-            packet.setEventType(1);
-            packet.setEventData(1);
             Level level = this.left.getHolder().getLevel();
             if (level != null) {
+                ContainerInventory.sendBlockEventPacket(this.right.getHolder(), 1);
                 level.addLevelSoundEvent(this.left.getHolder().getPosition(), SoundEvent.CHEST_OPEN);
-                level.addChunkPacket(this.left.getHolder().getPosition(), packet);
             }
         }
     }
@@ -131,15 +126,10 @@ public class DoubleChestInventory extends ContainerInventory implements Inventor
     @Override
     public void onClose(Player who) {
         if (this.getViewers().size() == 1) {
-            BlockEventPacket packet = new BlockEventPacket();
-            packet.setBlockPosition(this.left.getHolder().getPosition());
-            packet.setEventType(1);
-            packet.setEventData(0);
-
             Level level = this.right.getHolder().getLevel();
             if (level != null) {
+                ContainerInventory.sendBlockEventPacket(this.right.getHolder(), 0);
                 level.addLevelSoundEvent(this.right.getHolder().getPosition(), SoundEvent.CHEST_CLOSED);
-                level.addChunkPacket(right.getHolder().getPosition(), packet);
             }
         }
 

--- a/src/main/java/cn/nukkit/inventory/PlayerEnderChestInventory.java
+++ b/src/main/java/cn/nukkit/inventory/PlayerEnderChestInventory.java
@@ -6,7 +6,6 @@ import cn.nukkit.level.Level;
 import cn.nukkit.player.Player;
 import com.nukkitx.math.vector.Vector3i;
 import com.nukkitx.protocol.bedrock.data.SoundEvent;
-import com.nukkitx.protocol.bedrock.packet.BlockEventPacket;
 import com.nukkitx.protocol.bedrock.packet.ContainerClosePacket;
 import com.nukkitx.protocol.bedrock.packet.ContainerOpenPacket;
 
@@ -42,15 +41,10 @@ public class PlayerEnderChestInventory extends BaseInventory {
         this.sendContents(who);
 
         if (chest != null && chest.getViewers().size() == 1) {
-            BlockEventPacket blockEventPacket = new BlockEventPacket();
-            blockEventPacket.setBlockPosition(chest.getPosition());
-            blockEventPacket.setEventType(1);
-            blockEventPacket.setEventData(1);
-
             Level level = this.getHolder().getLevel();
             if (level != null) {
                 level.addLevelSoundEvent(this.getHolder().getPosition().add(0.5, 0.5, 0.5), SoundEvent.ENDERCHEST_OPEN);
-                level.addChunkPacket(this.getHolder().getPosition(), blockEventPacket);
+                ContainerInventory.sendBlockEventPacket(level.getBlockEntity(chest.getPosition()), 1);
             }
         }
     }
@@ -64,15 +58,10 @@ public class PlayerEnderChestInventory extends BaseInventory {
 
         BlockEnderChest chest = who.getViewingEnderChest();
         if (chest != null && chest.getViewers().size() == 1) {
-            BlockEventPacket blockEventPacket = new BlockEventPacket();
-            blockEventPacket.setBlockPosition(chest.getPosition());
-            blockEventPacket.setEventType(1);
-            blockEventPacket.setEventData(0);
-
             Level level = this.getHolder().getLevel();
             if (level != null) {
                 level.addLevelSoundEvent(this.getHolder().getPosition().add(0.5, 0.5, 0.5), SoundEvent.ENDERCHEST_CLOSED);
-                level.addChunkPacket(this.getHolder().getPosition(), blockEventPacket);
+                ContainerInventory.sendBlockEventPacket(level.getBlockEntity(chest.getPosition()), 0);
             }
 
             who.setViewingEnderChest(null);

--- a/src/main/java/cn/nukkit/inventory/ShulkerBoxInventory.java
+++ b/src/main/java/cn/nukkit/inventory/ShulkerBoxInventory.java
@@ -6,7 +6,6 @@ import cn.nukkit.item.Item;
 import cn.nukkit.level.Level;
 import cn.nukkit.player.Player;
 import com.nukkitx.protocol.bedrock.data.SoundEvent;
-import com.nukkitx.protocol.bedrock.packet.BlockEventPacket;
 
 /**
  * Created by PetteriM1
@@ -27,15 +26,10 @@ public class ShulkerBoxInventory extends ContainerInventory {
         super.onOpen(who);
 
         if (this.getViewers().size() == 1) {
-            BlockEventPacket packet = new BlockEventPacket();
-            packet.setBlockPosition(this.getHolder().getPosition());
-            packet.setEventType(1);
-            packet.setEventData(2);
-
             Level level = this.getHolder().getLevel();
             if (level != null) {
                 level.addLevelSoundEvent(this.getHolder().getPosition(), SoundEvent.SHULKERBOX_OPEN);
-                level.addChunkPacket(this.getHolder().getPosition(), packet);
+                ContainerInventory.sendBlockEventPacket(this.getHolder(), 1);
             }
         }
     }
@@ -43,15 +37,10 @@ public class ShulkerBoxInventory extends ContainerInventory {
     @Override
     public void onClose(Player who) {
         if (this.getViewers().size() == 1) {
-            BlockEventPacket packet = new BlockEventPacket();
-            packet.setBlockPosition(this.getHolder().getPosition());
-            packet.setEventType(1);
-            packet.setEventData(0);
-
             Level level = this.getHolder().getLevel();
             if (level != null) {
                 level.addLevelSoundEvent(this.getHolder().getPosition(), SoundEvent.SHULKERBOX_CLOSED);
-                level.addChunkPacket(this.getHolder().getPosition(), packet);
+                ContainerInventory.sendBlockEventPacket(this.getHolder(), 0);
             }
         }
 


### PR DESCRIPTION
removes duplicated `BlockEventPacket` code for `BlockEntities` with `InventoryTypes` that "open"