### PR TITLE
[1.0] Update BlockFromToEvent

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockLiquid.java
+++ b/src/main/java/cn/nukkit/block/BlockLiquid.java
@@ -234,7 +234,7 @@ public abstract class BlockLiquid extends BlockTransparentMeta {
                     BlockFromToEvent event = new BlockFromToEvent(this, to);
                     level.getServer().getPluginManager().callEvent(event);
                     if (!event.isCancelled()) {
-                        this.level.setBlock(this, to, true, true);
+                        this.level.setBlock(this, event.getTo(), true, true);
                         if (!decayed) {
                             this.level.scheduleUpdate(this, this.tickRate());
                         }
@@ -432,7 +432,7 @@ public abstract class BlockLiquid extends BlockTransparentMeta {
         if (event.isCancelled()) {
             return false;
         }
-        this.level.setBlock(this, result, true, true);
+        this.level.setBlock(this, event.getTo(), true, true);
         this.getLevel().addLevelSoundEvent(this.add(0.5, 0.5, 0.5), LevelSoundEventPacket.SOUND_FIZZ);
         return true;
     }

--- a/src/main/java/cn/nukkit/event/block/BlockFromToEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockFromToEvent.java
@@ -12,14 +12,22 @@ public class BlockFromToEvent extends BlockEvent implements Cancellable {
         return handlers;
     }
 
-    private final Block to;
+    private Block to;
 
     public BlockFromToEvent(Block block, Block to) {
         super(block);
         this.to = to;
     }
 
+    public Block getFrom() {
+        return getBlock();
+    }
+
     public Block getTo() {
         return to;
+    }
+
+    public void setTo(Block newTo) {
+        to = newTo;
     }
 }


### PR DESCRIPTION
Changes `BlockLiquid` functionality to use the `to` block returned  by the `BlockFromToEvent`. Also changes the `BlockFromToEvent` to allow Plugins to update the `To` block. 