### PR TITLE
BlockFallEvent

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockFallable.java
+++ b/src/main/java/cn/nukkit/block/BlockFallable.java
@@ -2,6 +2,7 @@ package cn.nukkit.block;
 
 import cn.nukkit.entity.Entity;
 import cn.nukkit.entity.item.EntityFallingBlock;
+import cn.nukkit.event.block.BlockFallEvent;
 import cn.nukkit.level.Level;
 import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.nbt.tag.DoubleTag;
@@ -21,7 +22,13 @@ public abstract class BlockFallable extends BlockSolid {
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_NORMAL) {
             Block down = this.down();
-            if (down.getId() == AIR || down instanceof BlockLiquid) {
+            if (down.getId() == AIR || down instanceof BlockLiquid || down instanceof BlockFire) {
+                BlockFallEvent event = new BlockFallEvent(this);
+                this.level.getServer().getPluginManager().callEvent(event);
+                if (event.isCancelled()) {
+                    return type;
+                }
+
                 this.level.setBlock(this, Block.get(Block.AIR), true, true);
                 CompoundTag nbt = new CompoundTag()
                         .putList(new ListTag<DoubleTag>("Pos")

--- a/src/main/java/cn/nukkit/event/block/BlockFallEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockFallEvent.java
@@ -1,0 +1,18 @@
+package cn.nukkit.event.block;
+
+import cn.nukkit.block.Block;
+import cn.nukkit.event.Cancellable;
+import cn.nukkit.event.HandlerList;
+
+public class BlockFallEvent extends BlockEvent implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    public static HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public BlockFallEvent(Block block) {
+        super(block);
+    }
+}


### PR DESCRIPTION
Thrown when a block physics check is called. (gravel, sand, dragon egg, concrete powder, snow layers and anvil)

If a Block Fall event is cancelled, the block will not fall.