### PR TITLE
Remove duplicate speed effect ID

### DIFF
--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -1631,8 +1631,8 @@ public class Level implements ChunkManager, Metadatable {
                 breakTime = 0.15;
             }
 
-            if (player.hasEffect(Effect.SWIFTNESS)) {
-                breakTime *= 1 - (0.2 * (player.getEffect(Effect.SWIFTNESS).getAmplifier() + 1));
+            if (player.hasEffect(Effect.HASTE)) {
+                breakTime *= 1 - (0.2 * (player.getEffect(Effect.HASTE).getAmplifier() + 1));
             }
 
             if (player.hasEffect(Effect.MINING_FATIGUE)) {

--- a/src/main/java/cn/nukkit/potion/Effect.java
+++ b/src/main/java/cn/nukkit/potion/Effect.java
@@ -17,7 +17,7 @@ import static com.nukkitx.protocol.bedrock.data.EntityFlag.INVISIBLE;
  */
 public class Effect implements Cloneable {
 
-    public static final int SPEED = 1;
+    public static final int SWIFTNESS = 1;
     public static final int SLOWNESS = 2;
     public static final int HASTE = 3;
     public static final int FATIGUE = 4;
@@ -62,7 +62,7 @@ public class Effect implements Cloneable {
     public static void init() {
         effects = new Effect[256];
 
-        effects[Effect.SPEED] = new Effect(Effect.SPEED, "%potion.moveSpeed", 124, 175, 198);
+        effects[Effect.SWIFTNESS] = new Effect(Effect.SWIFTNESS, "%potion.moveSpeed", 124, 175, 198);
         effects[Effect.SLOWNESS] = new Effect(Effect.SLOWNESS, "%potion.moveSlowdown", 90, 108, 129, true);
         effects[Effect.HASTE] = new Effect(Effect.HASTE, "%potion.digSpeed", 217, 192, 67);
         effects[Effect.FATIGUE] = new Effect(Effect.FATIGUE, "%potion.digSlowDown", 74, 66, 23, true);

--- a/src/main/java/cn/nukkit/potion/Effect.java
+++ b/src/main/java/cn/nukkit/potion/Effect.java
@@ -20,7 +20,6 @@ public class Effect implements Cloneable {
     public static final int SPEED = 1;
     public static final int SLOWNESS = 2;
     public static final int HASTE = 3;
-    public static final int SWIFTNESS = 3;
     public static final int FATIGUE = 4;
     public static final int MINING_FATIGUE = 4;
     public static final int STRENGTH = 5;
@@ -65,7 +64,7 @@ public class Effect implements Cloneable {
 
         effects[Effect.SPEED] = new Effect(Effect.SPEED, "%potion.moveSpeed", 124, 175, 198);
         effects[Effect.SLOWNESS] = new Effect(Effect.SLOWNESS, "%potion.moveSlowdown", 90, 108, 129, true);
-        effects[Effect.SWIFTNESS] = new Effect(Effect.SWIFTNESS, "%potion.digSpeed", 217, 192, 67);
+        effects[Effect.HASTE] = new Effect(Effect.HASTE, "%potion.digSpeed", 217, 192, 67);
         effects[Effect.FATIGUE] = new Effect(Effect.FATIGUE, "%potion.digSlowDown", 74, 66, 23, true);
         effects[Effect.STRENGTH] = new Effect(Effect.STRENGTH, "%potion.damageBoost", 147, 36, 35);
         effects[Effect.HEALING] = new InstantEffect(Effect.HEALING, "%potion.heal", 248, 36, 35);

--- a/src/main/java/cn/nukkit/potion/Effect.java
+++ b/src/main/java/cn/nukkit/potion/Effect.java
@@ -267,7 +267,7 @@ public class Effect implements Cloneable {
 
             player.sendPacket(packet);
 
-            if (this.id == Effect.SPEED) {
+            if (this.id == Effect.SWIFTNESS) {
                 if (oldEffect != null) {
                     player.setMovementSpeed(player.getMovementSpeed() / (1 + 0.2f * (oldEffect.amplifier + 1)), false);
                 }
@@ -302,7 +302,7 @@ public class Effect implements Cloneable {
 
             ((Player) entity).sendPacket(packet);
 
-            if (this.id == Effect.SPEED) {
+            if (this.id == Effect.SWIFTNESS) {
                 ((Player) entity).setMovementSpeed(((Player) entity).getMovementSpeed() / (1 + 0.2f * (this.amplifier + 1)));
             }
             if (this.id == Effect.SLOWNESS) {

--- a/src/main/java/cn/nukkit/potion/Potion.java
+++ b/src/main/java/cn/nukkit/potion/Potion.java
@@ -256,7 +256,7 @@ public class Potion implements Cloneable {
             case SPEED:
             case SPEED_LONG:
             case SPEED_II:
-                effect = Effect.getEffect(Effect.SPEED);
+                effect = Effect.getEffect(Effect.SWIFTNESS);
                 break;
             case SLOWNESS:
             case SLOWNESS_LONG:


### PR DESCRIPTION
Originally, there were 2 speed IDs with different values, one of them being actual speed, and the other being swiftness. I removed the swiftness one & also replaced the swiftness effect initialization with haste.