### PR TITLE
Update Op Command Usage.

### DIFF
--- a/src/main/java/cn/nukkit/command/defaults/OpCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/OpCommand.java
@@ -30,7 +30,7 @@ public class OpCommand extends VanillaCommand {
             return true;
         }
         if (args.length == 0) {
-            sender.sendMessage(new TranslationContainer("commands.generic.usage", this.usageMessage));
+            sender.sendMessage(new TranslationContainer("commands.op.usage", this.usageMessage));
             return false;
         }
 


### PR DESCRIPTION
A Fix because when you type normally /op without any arguments it shows %commands.op.description, now it works flawless.