### PR TITLE
[1.0] Remove player levels on enchant

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2774,7 +2774,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             }
 
                             int levels = entityEventPacket.data; // Sent as negative number of levels lost
-                            this.setExperience(this.exp, this.expLevel + levels);
+                            if (levels < 0) this.setExperience(this.exp, this.expLevel + levels);
                             break;
                     }
                     break;

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2750,10 +2750,11 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     if (!this.spawned || !this.isAlive()) {
                         break;
                     }
-                    this.craftingType = CRAFTING_SMALL;
+                    EntityEventPacket entityEventPacket = (EntityEventPacket) packet;
+                    if (entityEventPacket.event != EntityEventPacket.ENCHANT)
+                        this.craftingType = CRAFTING_SMALL;
                     //this.resetCraftingGridType();
 
-                    EntityEventPacket entityEventPacket = (EntityEventPacket) packet;
 
                     switch (entityEventPacket.event) {
                         case EntityEventPacket.EATING_ITEM:
@@ -2766,6 +2767,14 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
                             this.dataPacket(entityEventPacket);
                             Server.broadcastPacket(this.getViewers().values(), entityEventPacket);
+                            break;
+                        case EntityEventPacket.ENCHANT:
+                            if (entityEventPacket.eid != this.id) {
+                                break;
+                            }
+
+                            int levels = entityEventPacket.data; // Sent as negative number of levels lost
+                            this.setExperience(this.exp, this.expLevel + levels);
                             break;
                     }
                     break;


### PR DESCRIPTION
The server was not removing the levels from the player server-side, so next time XP was gained, the old level value was sent to the client. 
Fixes #1374