### PR TITLE
[2.0] Use AIR BLOCK instead of throwing exception for blocks unregistred.

### DIFF
--- a/src/main/java/cn/nukkit/registry/BlockRegistry.java
+++ b/src/main/java/cn/nukkit/registry/BlockRegistry.java
@@ -164,7 +164,8 @@ public class BlockRegistry implements Registry {
     public int getLegacyId(Identifier identifier) {
         int legacyId = this.idLegacyMap.getOrDefault(identifier, -1);
         if (legacyId == -1) {
-            throw new RegistryException("No legacy ID found for " + identifier);
+            legacyId = getLegacyId(AIR);
+            //throw new RegistryException("No legacy ID found for " + identifier);
         }
         return legacyId;
     }


### PR DESCRIPTION
I think that's better or just be an option for players who wants that.

For now, let's just vote for that.