### PR TITLE
Fix NBT loading errors (hotfix)

### DIFF
--- a/src/main/java/cn/nukkit/level/GlobalBlockPalette.java
+++ b/src/main/java/cn/nukkit/level/GlobalBlockPalette.java
@@ -4,9 +4,11 @@ import cn.nukkit.Server;
 import cn.nukkit.nbt.NBTIO;
 import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.nbt.tag.ListTag;
+import com.google.common.io.ByteStreams;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteOrder;
@@ -24,14 +26,13 @@ public class GlobalBlockPalette {
         legacyToRuntimeId.defaultReturnValue(-1);
         runtimeIdToLegacy.defaultReturnValue(-1);
 
-        InputStream stream = Server.class.getClassLoader().getResourceAsStream("runtime_block_states.dat");
-        if (stream == null) {
-            throw new AssertionError("Unable to locate block state nbt");
-        }
         ListTag<CompoundTag> tag;
-        try {
+        try (InputStream stream = Server.class.getClassLoader().getResourceAsStream("runtime_block_states.dat")) {
+            if (stream == null) {
+                throw new AssertionError("Unable to locate block state nbt");
+            }
             //noinspection unchecked
-            tag = (ListTag<CompoundTag>) NBTIO.readTag(stream, ByteOrder.LITTLE_ENDIAN, false);
+            tag = (ListTag<CompoundTag>) NBTIO.readTag(new ByteArrayInputStream(ByteStreams.toByteArray(stream)), ByteOrder.LITTLE_ENDIAN, false);
         } catch (IOException e) {
             throw new AssertionError("Unable to load block palette", e);
         }

--- a/src/main/java/cn/nukkit/nbt/stream/NBTInputStream.java
+++ b/src/main/java/cn/nukkit/nbt/stream/NBTInputStream.java
@@ -81,11 +81,7 @@ public class NBTInputStream implements DataInput, AutoCloseable {
 
     @Override
     public int readUnsignedShort() throws IOException {
-        int s = this.stream.readUnsignedShort();
-        if (endianness == ByteOrder.LITTLE_ENDIAN) {
-            s = Integer.reverseBytes(s) >>> 16;
-        }
-        return s;
+        return this.readShort() & 0xFFFF;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/nbt/stream/NBTInputStream.java
+++ b/src/main/java/cn/nukkit/nbt/stream/NBTInputStream.java
@@ -83,7 +83,7 @@ public class NBTInputStream implements DataInput, AutoCloseable {
     public int readUnsignedShort() throws IOException {
         int s = this.stream.readUnsignedShort();
         if (endianness == ByteOrder.LITTLE_ENDIAN) {
-            s = Integer.reverseBytes(s) >> 16;
+            s = Integer.reverseBytes(s) >>> 16;
         }
         return s;
     }
@@ -147,7 +147,7 @@ public class NBTInputStream implements DataInput, AutoCloseable {
 
     @Override
     public String readUTF() throws IOException {
-        int length = (int) (network ? VarInt.readUnsignedVarInt(stream) : this.readUnsignedShort());
+        int length = network ? (int) VarInt.readUnsignedVarInt(stream) : this.readUnsignedShort();
         byte[] bytes = new byte[length];
         this.stream.read(bytes);
         return new String(bytes, StandardCharsets.UTF_8);


### PR DESCRIPTION
Somehow there are some issues when loading resources from the compiled jar, and reading it into a `byte[]` first fixes it.

Also fixes reading unsigned shorts from NBT tags.