### PR TITLE
fixed issue 1392

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -4198,7 +4198,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         MovePlayerPacket pk = new MovePlayerPacket();
         pk.eid = this.getId();
         pk.x = (float) pos.x;
-        pk.y = (float) (pos.y + this.getEyeHeight());
+        pk.y = (float) pos.y;
         pk.z = (float) pos.z;
         pk.headYaw = (float) yaw;
         pk.pitch = (float) pitch;


### PR DESCRIPTION
https://github.com/NukkitX/Nukkit/issues/1392
Teleported account's position is sent added with eye height. Fixed by removing the addition of eye height.