### PR TITLE
[2.0] Fix grass drops and placing on already placed grass

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockDoublePlant.java
+++ b/src/main/java/cn/nukkit/block/BlockDoublePlant.java
@@ -87,27 +87,20 @@ public class BlockDoublePlant extends FloodableBlock {
     @Override
     public Item[] getDrops(Item item) {
         if ((this.getMeta() & TOP_HALF_BITMASK) != TOP_HALF_BITMASK) {
+            boolean dropSeeds = ThreadLocalRandom.current().nextDouble(100) > 87.5;
             switch (this.getMeta() & 0x07) {
                 case TALL_GRASS:
                 case LARGE_FERN:
-                    boolean dropSeeds = ThreadLocalRandom.current().nextInt(10) == 0;
                     if (item.isShears()) {
                         //todo enchantment
-                        if (dropSeeds) {
-                            return new Item[]{
-                                    Item.get(ItemIds.WHEAT, 0, 1),
-                                    toItem()
-                            };
-                        } else {
-                            return new Item[]{
-                                    toItem()
-                            };
-                        }
+                        return new Item[] {
+                                Item.get(BlockIds.TALL_GRASS, (this.getMeta() & 0x07) == TALL_GRASS ? 1 : 2, 2)
+                        };
                     }
 
                     if (dropSeeds) {
                         return new Item[]{
-                                Item.get(ItemIds.WHEAT)
+                                Item.get(ItemIds.WHEAT_SEEDS)
                         };
                     } else {
                         return new Item[0];

--- a/src/main/java/cn/nukkit/block/BlockTallGrass.java
+++ b/src/main/java/cn/nukkit/block/BlockTallGrass.java
@@ -48,6 +48,10 @@ public class BlockTallGrass extends FloodableBlock {
 
     @Override
     public boolean place(Item item, Block block, Block target, BlockFace face, Vector3f clickPos, Player player) {
+        // Prevents from placing the same plant block on itself
+        if (item.getId() == target.getId() && item.getMeta() == block.getMeta()) {
+            return false;
+        }
         Block down = this.down();
         if (down.getId() == GRASS || down.getId() == DIRT || down.getId() == PODZOL) {
             this.getLevel().setBlock(block.getPosition(), this, true);
@@ -107,19 +111,12 @@ public class BlockTallGrass extends FloodableBlock {
 
     @Override
     public Item[] getDrops(Item item) {
-        boolean dropSeeds = ThreadLocalRandom.current().nextInt(10) == 0;
+        boolean dropSeeds = ThreadLocalRandom.current().nextDouble(100) > 87.5;
         if (item.isShears()) {
             //todo enchantment
-            if (dropSeeds) {
-                return new Item[]{
-                        Item.get(ItemIds.WHEAT_SEEDS),
+            return new Item[]{
                         Item.get(BlockIds.TALL_GRASS, this.getMeta(), 1)
                 };
-            } else {
-                return new Item[]{
-                        Item.get(BlockIds.TALL_GRASS, this.getMeta(), 1)
-                };
-            }
         }
 
         if (dropSeeds) {


### PR DESCRIPTION
Fixes a few bugs with grass and double tallgrass.

- Fixed grass drops (dropped wheat instead of seeds on double plants).
- Fixed double tallgrass dropping double trallgrass instead of two normal grass.
- Adjusted seed drop percentage (it's 12.5% instead of 10% according to the wiki).
- Fixed bug where placing grass on top of already placed grass would place what was in the inventory and thus decremented the amount there.