### PR TITLE
filter files to be used for legacy playerdata conversion correctly

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -1490,7 +1490,7 @@ public class Server {
         File[] files = dataDirectory.listFiles(file -> {
             String name = file.getName();
             Matcher matcher = UUID_PATTERN.matcher(name);
-            return !matcher.matches();
+            return !matcher.matches() && name.endsWith(".dat");
         });
 
         if (files == null) {


### PR DESCRIPTION
see #1464 

apparently the additional check for files that end in `.dat` was, in fact, critical