### PR TITLE
Show 'Update Game!' block instead of throwing an exception.

### DIFF
--- a/src/main/java/cn/nukkit/level/GlobalBlockPalette.java
+++ b/src/main/java/cn/nukkit/level/GlobalBlockPalette.java
@@ -7,6 +7,7 @@ import cn.nukkit.nbt.tag.ListTag;
 import com.google.common.io.ByteStreams;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import lombok.extern.log4j.Log4j2;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -16,6 +17,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+@Log4j2
 public class GlobalBlockPalette {
     private static final Int2IntMap legacyToRuntimeId = new Int2IntOpenHashMap();
     private static final Int2IntMap runtimeIdToLegacy = new Int2IntOpenHashMap();
@@ -67,7 +69,10 @@ public class GlobalBlockPalette {
         if (runtimeId == -1) {
             runtimeId = legacyToRuntimeId.get(id << 6);
             if (runtimeId == -1) {
-                throw new NoSuchElementException("Unmapped block registered id:" + id + " meta:" + meta);
+                log.info("Creating new runtime ID for unknown block {}", id);
+                runtimeId = runtimeIdAllocator.getAndIncrement();
+                legacyToRuntimeId.put(id << 6, runtimeId);
+                runtimeIdToLegacy.put(runtimeId, id << 6);
             }
         }
         return runtimeId;


### PR DESCRIPTION
This should allow chunks to load if invalid blocks are contained within it.