### PR TITLE
[1.16] CreativeContentPacket fix

### DIFF
--- a/src/main/java/cn/nukkit/network/protocol/CreativeContentPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/CreativeContentPacket.java
@@ -23,9 +23,9 @@ public class CreativeContentPacket extends DataPacket {
     public void encode() {
         this.reset();
         this.putVarInt(entries.length);
-        for (Item item : entries) {
-            this.putUnsignedVarInt(item.getId());
-            this.putSlot(item);
+        for (int i = 0; i < entries.length; i++) {
+            this.putUnsignedVarInt(i + 1);
+            this.putSlot(entries[i]);
         }
 
     }

--- a/src/main/resources/recipes.json
+++ b/src/main/resources/recipes.json
@@ -19,11 +19,11 @@
       "input": [
         {
           "id": 339,
-          "damage": 32767
+          "damage": -1
         },
         {
           "id": 345,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -41,7 +41,7 @@
       "input": [
         {
           "id": 339,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -116,7 +116,7 @@
       "input": [
         {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -134,7 +134,7 @@
       "input": [
         {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -151,7 +151,7 @@
       "input": [
         {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -186,7 +186,7 @@
       "input": [
         {
           "id": -291,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -220,7 +220,7 @@
       "input": [
         {
           "id": -291,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -254,7 +254,7 @@
       "input": [
         {
           "id": -291,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -271,7 +271,7 @@
       "input": [
         {
           "id": -291,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -288,7 +288,7 @@
       "input": [
         {
           "id": -291,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -305,7 +305,7 @@
       "input": [
         {
           "id": 112,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -322,7 +322,7 @@
       "input": [
         {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -912,7 +912,7 @@
       "input": [
         {
           "id": -234,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -929,7 +929,7 @@
       "input": [
         {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -947,7 +947,7 @@
       "input": [
         {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -964,7 +964,7 @@
       "input": [
         {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -981,7 +981,7 @@
       "input": [
         {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -1088,7 +1088,7 @@
       "input": [
         {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -1195,7 +1195,7 @@
       "input": [
         {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -1213,7 +1213,7 @@
       "input": [
         {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -1230,7 +1230,7 @@
       "input": [
         {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -1385,7 +1385,7 @@
       "input": [
         {
           "id": 155,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -1690,7 +1690,7 @@
       "input": [
         {
           "id": -291,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -1708,7 +1708,7 @@
       "input": [
         {
           "id": -274,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -1851,7 +1851,7 @@
       "input": [
         {
           "id": -291,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -2019,7 +2019,7 @@
       "input": [
         {
           "id": -291,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -2036,7 +2036,7 @@
       "input": [
         {
           "id": -274,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -2053,7 +2053,7 @@
       "input": [
         {
           "id": -274,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -2070,11 +2070,11 @@
       "input": {
         "A": {
           "id": 5,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 340,
-          "damage": 32767
+          "damage": -1
                 }
             },
             "output" : [
@@ -2096,7 +2096,7 @@
             "input" : {
                 "A" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -2218,7 +2218,7 @@
             "input" : {
                 "A" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -2243,11 +2243,11 @@
                 },
                 "B" : {
                     "id" : 406,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "C" : {
                     "id" : 158,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -2269,7 +2269,7 @@
             "input" : [
                 {
                     "id" : 377,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 263,
@@ -2277,7 +2277,7 @@
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -2295,15 +2295,15 @@
             "input" : [
                 {
                     "id" : 377,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 263,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -2321,11 +2321,11 @@
             "input" : {
                 "A" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 264,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -2347,11 +2347,11 @@
             "input" : {
                 "A" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 331,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -2436,11 +2436,11 @@
             "input" : {
                 "A" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 35,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -2462,18 +2462,18 @@
             "input" : {
                 "A" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 4
                 },
                 "C" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "D" : {
                     "id" : 331,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -2720,11 +2720,11 @@
             "input" : {
                 "A" : {
                     "id" : 263,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -2877,15 +2877,15 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "C" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -2946,7 +2946,7 @@
             "input" : {
                 "A" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -3005,7 +3005,7 @@
                 },
                 "B" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -3030,7 +3030,7 @@
                 },
                 "B" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -3056,7 +3056,7 @@
                 },
                 "B" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -3082,7 +3082,7 @@
                 },
                 "B" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -3108,7 +3108,7 @@
                 },
                 "B" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -3134,7 +3134,7 @@
                 },
                 "B" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -3160,7 +3160,7 @@
                 },
                 "B" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -3186,7 +3186,7 @@
                 },
                 "B" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -3212,7 +3212,7 @@
                 },
                 "B" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -3238,7 +3238,7 @@
                 },
                 "B" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -3264,7 +3264,7 @@
                 },
                 "B" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -3290,7 +3290,7 @@
                 },
                 "B" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -3316,7 +3316,7 @@
                 },
                 "B" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -3342,7 +3342,7 @@
                 },
                 "B" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -3368,7 +3368,7 @@
                 },
                 "B" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -3394,7 +3394,7 @@
                 },
                 "B" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -3419,7 +3419,7 @@
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3444,7 +3444,7 @@
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3470,7 +3470,7 @@
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3496,7 +3496,7 @@
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3522,7 +3522,7 @@
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3548,7 +3548,7 @@
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3574,7 +3574,7 @@
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3600,7 +3600,7 @@
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3626,7 +3626,7 @@
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3652,7 +3652,7 @@
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3678,7 +3678,7 @@
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3704,7 +3704,7 @@
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3730,7 +3730,7 @@
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3756,7 +3756,7 @@
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3782,7 +3782,7 @@
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3808,7 +3808,7 @@
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3833,7 +3833,7 @@
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3858,7 +3858,7 @@
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3884,7 +3884,7 @@
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3910,7 +3910,7 @@
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3936,7 +3936,7 @@
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3962,7 +3962,7 @@
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -3988,7 +3988,7 @@
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -4014,7 +4014,7 @@
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -4040,7 +4040,7 @@
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -4066,7 +4066,7 @@
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -4092,7 +4092,7 @@
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -4118,7 +4118,7 @@
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -4144,7 +4144,7 @@
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -4170,7 +4170,7 @@
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -4196,7 +4196,7 @@
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -4222,7 +4222,7 @@
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -10971,11 +10971,11 @@
             "input" : {
                 "A" : {
                     "id" : 287,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -11000,7 +11000,7 @@
                 },
                 "B" : {
                   "id": 269,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -11049,7 +11049,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -11072,7 +11072,7 @@
             "input" : {
                 "A" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 5,
@@ -11118,7 +11118,7 @@
             "input" : {
                 "A" : {
                     "id" : -8,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -11229,7 +11229,7 @@
             "input" : {
                 "A" : {
                     "id" : -8,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -11274,15 +11274,15 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "C" : {
                     "id" : 76,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -11309,7 +11309,7 @@
                 },
                 {
                     "id" : 4,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -11374,11 +11374,11 @@
             "input" : {
                 "A" : {
                     "id" : 42,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -11400,7 +11400,7 @@
             "input" : {
                 "A" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 44
@@ -11425,15 +11425,15 @@
             "input" : {
                 "A" : {
                     "id" : 318,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "C" : {
                     "id" : 288,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -11456,11 +11456,11 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 45,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -11478,7 +11478,7 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 397,
@@ -11499,7 +11499,7 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 38,
@@ -11521,7 +11521,7 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 397,
@@ -11543,11 +11543,11 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 466,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -11565,11 +11565,11 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 106,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -11587,11 +11587,11 @@
             "input" : {
                 "A" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 158,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -11613,11 +11613,11 @@
       "input": {
         "A": {
           "id": -264,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -11639,11 +11639,11 @@
       "input": {
         "A": {
           "id": -265,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -11669,7 +11669,7 @@
         },
         {
           "id": 345,
-          "damage": 32767
+          "damage": -1
                 }
             ],
             "output" : [
@@ -11687,15 +11687,15 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 399,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "C" : {
                     "id" : 49,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -11717,11 +11717,11 @@
             "input" : {
                 "A" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 736,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -11744,11 +11744,11 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 736,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -11771,11 +11771,11 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 736,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -11798,31 +11798,31 @@
       "input": [
         {
           "id": 281,
-          "damage": 32767
+          "damage": -1
         },
         {
           "id": 457,
-          "damage": 32767
+          "damage": -1
                 },
                 {
                     "id" : 457,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 457,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 457,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 457,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 457,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -11843,7 +11843,7 @@
                 },
                 "B" : {
                   "id": 269,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -11892,7 +11892,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -11915,7 +11915,7 @@
             "input" : {
                 "A" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 5,
@@ -11962,7 +11962,7 @@
             "input" : {
                 "A" : {
                     "id" : -6,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -12074,7 +12074,7 @@
             "input" : {
                 "A" : {
                     "id" : -6,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -12123,7 +12123,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -12210,19 +12210,19 @@
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -12256,19 +12256,19 @@
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -12304,7 +12304,7 @@
             "input" : [
                 {
                     "id" : -216,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -12322,7 +12322,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -12350,7 +12350,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351
@@ -12400,7 +12400,7 @@
             "input" : {
                 "A" : {
                     "id" : 102,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -12428,7 +12428,7 @@
             "input" : {
                 "A" : {
                     "id" : 172,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -12456,7 +12456,7 @@
             "input" : {
                 "A" : {
                     "id" : 172,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351
@@ -12483,7 +12483,7 @@
       "input": {
         "A": {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -12504,7 +12504,7 @@
       "input": {
         "A": {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -12527,7 +12527,7 @@
       "input": {
         "A": {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -12549,15 +12549,15 @@
       "input": {
         "A": {
           "id": 265,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 61,
-          "damage": 32767
+          "damage": -1
                 },
                 "C" : {
                     "id" : -183,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -12579,7 +12579,7 @@
             "input" : [
                 {
                     "id" : 369,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -12601,7 +12601,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -12689,19 +12689,19 @@
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -12736,19 +12736,19 @@
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -12803,7 +12803,7 @@
             "input" : {
                 "A" : {
                     "id" : 174,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -12825,7 +12825,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -12853,7 +12853,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -12904,7 +12904,7 @@
             "input" : {
                 "A" : {
                     "id" : 102,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -12932,7 +12932,7 @@
             "input" : {
                 "A" : {
                     "id" : 172,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -12960,7 +12960,7 @@
             "input" : {
                 "A" : {
                     "id" : 172,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -12991,7 +12991,7 @@
                 },
                 "B" : {
                   "id": 269,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -13034,7 +13034,7 @@
             "input" : [
                 {
                     "id" : 216,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -13053,7 +13053,7 @@
             "input" : [
                 {
                     "id" : 352,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -13097,11 +13097,11 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 340,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -13123,11 +13123,11 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 340,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -13149,11 +13149,11 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 287,
-          "damage": 32767
+          "damage": -1
                 }
             },
             "output" : [
@@ -13175,7 +13175,7 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -13197,7 +13197,7 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -13219,7 +13219,7 @@
       "input": {
         "A": {
           "id": 296,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -13239,11 +13239,11 @@
             "input" : {
                 "A" : {
                     "id" : 369,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 4,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -13264,7 +13264,7 @@
             "input" : {
                 "A" : {
                     "id" : 336,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -13285,7 +13285,7 @@
             "input" : {
                 "A" : {
                     "id" : 45,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -13308,7 +13308,7 @@
             "input" : {
                 "A" : {
                     "id" : 45,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -13335,7 +13335,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -13423,19 +13423,19 @@
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -13470,19 +13470,19 @@
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -13519,7 +13519,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -13547,7 +13547,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -13598,7 +13598,7 @@
             "input" : {
                 "A" : {
                     "id" : 102,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -13626,7 +13626,7 @@
             "input" : {
                 "A" : {
                     "id" : 172,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -13654,7 +13654,7 @@
             "input" : {
                 "A" : {
                     "id" : 172,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -13682,7 +13682,7 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -13707,15 +13707,15 @@
                 },
                 "B" : {
                     "id" : 353,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "C" : {
                     "id" : 344,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "D" : {
                     "id" : 296,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -13741,15 +13741,15 @@
             "input" : {
                 "A" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 263,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "C" : {
                     "id" : 17,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -13771,15 +13771,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 263,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -225,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -13801,15 +13801,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
                     "id" : 263,
-          "damage": 32767
+          "damage": -1
                 },
                 "C" : {
                     "id" : 162,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -13831,15 +13831,15 @@
             "input" : {
                 "A" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 263,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "C" : {
                     "id" : -8,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -13861,15 +13861,15 @@
             "input" : {
                 "A" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 263,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "C" : {
                     "id" : -6,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -13891,15 +13891,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 263,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -240,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -13921,15 +13921,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
                     "id" : 263,
-          "damage": 32767
+          "damage": -1
                 },
                 "C" : {
                     "id" : -9,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -13951,15 +13951,15 @@
             "input" : {
                 "A" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 263,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "C" : {
                     "id" : -7,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -13981,15 +13981,15 @@
             "input" : {
                 "A" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 263,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "C" : {
                     "id" : -10,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -14011,15 +14011,15 @@
             "input" : {
                 "A" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 263,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "C" : {
                     "id" : -5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -14041,15 +14041,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 263,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -241,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14071,15 +14071,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 263,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -226,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14101,15 +14101,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
                     "id" : 263,
-          "damage": 32767
+          "damage": -1
                 },
                 "C" : {
                     "id" : -212,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -14131,11 +14131,11 @@
             "input" : {
                 "A" : {
                   "id": 346,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 391,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -14156,11 +14156,11 @@
             "input" : {
                 "A" : {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -14182,11 +14182,11 @@
       "input": {
         "A": {
           "id": 339,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14208,11 +14208,11 @@
       "input": {
         "A": {
           "id": 339,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14234,7 +14234,7 @@
       "input": {
         "A": {
           "id": 265,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14256,11 +14256,11 @@
       "input": {
         "A": {
           "id": 452,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 265,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14282,7 +14282,7 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14304,7 +14304,7 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14326,11 +14326,11 @@
       "input": {
         "A": {
           "id": 54,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 328,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14372,7 +14372,7 @@
       "input": {
         "A": {
           "id": -293,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14393,7 +14393,7 @@
       "input": {
         "A": {
           "id": 337,
-          "damage": 32767
+          "damage": -1
                 }
             },
             "output" : [
@@ -14414,11 +14414,11 @@
             "input" : {
                 "A" : {
                     "id" : 266,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 331,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -14440,7 +14440,7 @@
             "input" : {
                 "A" : {
                     "id" : 173,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -14485,7 +14485,7 @@
                 },
                 "B" : {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -14508,7 +14508,7 @@
             "input" : {
                 "A" : {
                     "id" : 4,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -14531,7 +14531,7 @@
             "input" : {
                 "A" : {
                     "id" : 4,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -14553,7 +14553,7 @@
             "input" : [
                 {
                     "id" : 30,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -14571,11 +14571,11 @@
             "input" : {
                 "A" : {
                     "id" : 76,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 406,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "C" : {
                     "id" : 1
@@ -14600,11 +14600,11 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 331,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -14626,7 +14626,7 @@
             "input" : {
                 "A" : {
                     "id" : 158,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -14648,7 +14648,7 @@
       "input": {
         "A": {
           "id": -264,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14670,7 +14670,7 @@
       "input": {
         "A": {
           "id": -265,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14692,11 +14692,11 @@
       "input": {
         "A": {
           "id": 465,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 467,
-          "damage": 32767
+          "damage": -1
                 }
             },
             "output" : [
@@ -14718,7 +14718,7 @@
             "input" : {
                 "A" : {
                     "id" : 296,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -14743,7 +14743,7 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14764,7 +14764,7 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14785,7 +14785,7 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14805,7 +14805,7 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14828,11 +14828,11 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14854,11 +14854,11 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14879,7 +14879,7 @@
       "input": {
         "A": {
           "id": -225,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14901,7 +14901,7 @@
       "input": {
         "A": {
           "id": -225,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14922,7 +14922,7 @@
       "input": {
         "A": {
           "id": -299,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14943,7 +14943,7 @@
       "input": {
         "A": {
           "id": -300,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14964,7 +14964,7 @@
       "input": {
         "A": {
           "id": -240,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -14985,7 +14985,7 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -15005,11 +15005,11 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -15032,7 +15032,7 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -15053,7 +15053,7 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -15076,7 +15076,7 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -15098,19 +15098,19 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 265,
-          "damage": 32767
+          "damage": -1
                 },
                 "C" : {
                     "id" : 287,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "D" : {
                     "id" : 131,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -15136,7 +15136,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -15224,19 +15224,19 @@
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -15301,7 +15301,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -15352,7 +15352,7 @@
             "input" : {
                 "A" : {
                     "id" : 102,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -15380,7 +15380,7 @@
             "input" : {
                 "A" : {
                     "id" : 172,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -15412,7 +15412,7 @@
                 },
                 "B" : {
                   "id": 269,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -15461,7 +15461,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -15484,7 +15484,7 @@
             "input" : {
                 "A" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 5,
@@ -15531,7 +15531,7 @@
             "input" : {
                 "A" : {
                     "id" : -9,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -15643,7 +15643,7 @@
             "input" : {
                 "A" : {
                     "id" : -9,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -15688,7 +15688,7 @@
             "input" : {
                 "A" : {
                     "id" : 409,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -15715,7 +15715,7 @@
             "input" : {
                 "A" : {
                     "id" : 409,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351
@@ -15741,15 +15741,15 @@
       "input": {
         "A": {
           "id": 20,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 406,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -264,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -15771,15 +15771,15 @@
       "input": {
         "A": {
           "id": 20,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 406,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -265,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -15801,15 +15801,15 @@
       "input": {
         "A": {
           "id": 265,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 70,
-          "damage": 32767
+          "damage": -1
                 },
                 "C" : {
                     "id" : 331,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -15832,7 +15832,7 @@
             "input" : {
                 "A" : {
                     "id" : 57,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -15853,11 +15853,11 @@
             "input" : {
                 "A" : {
                     "id" : 264,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -15879,7 +15879,7 @@
             "input" : {
                 "A" : {
                     "id" : 264,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -15901,7 +15901,7 @@
             "input" : {
                 "A" : {
                     "id" : 264,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -15922,7 +15922,7 @@
             "input" : {
                 "A" : {
                     "id" : 264,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -15944,7 +15944,7 @@
             "input" : {
                 "A" : {
                     "id" : 264,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -15965,11 +15965,11 @@
             "input" : {
                 "A" : {
                     "id" : 264,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -15991,7 +15991,7 @@
             "input" : {
                 "A" : {
                     "id" : 264,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16013,11 +16013,11 @@
             "input" : {
                 "A" : {
                     "id" : 264,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16039,11 +16039,11 @@
             "input" : {
                 "A" : {
                     "id" : 264,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16065,11 +16065,11 @@
             "input" : {
                 "A" : {
                     "id" : 264,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16091,11 +16091,11 @@
             "input" : {
                 "A" : {
                     "id" : 4,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 406,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16164,15 +16164,15 @@
             "input" : {
                 "A" : {
                     "id" : 4,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                   "id": 261,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "C" : {
                     "id" : 331,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16195,7 +16195,7 @@
             "input" : {
                 "A" : {
                     "id" : -139,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16216,7 +16216,7 @@
             "input" : {
                 "A" : {
                     "id" : 464,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16238,11 +16238,11 @@
             "input" : {
                 "A" : {
                     "id" : 4,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 331,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16265,7 +16265,7 @@
             "input" : {
                 "A" : {
                     "id" : 133,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16286,7 +16286,7 @@
             "input" : {
                 "A" : {
                     "id" : 388,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16311,7 +16311,7 @@
                 },
                 {
                     "id" : 345,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -16329,15 +16329,15 @@
             "input" : {
                 "A" : {
                     "id" : 340,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 264,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "C" : {
                     "id" : 49,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16359,7 +16359,7 @@
             "input" : {
                 "A" : {
                     "id" : 206,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16382,7 +16382,7 @@
             "input" : {
                 "A" : {
                     "id" : 206,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16405,7 +16405,7 @@
             "input" : {
                 "A" : {
                     "id" : 121,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16427,15 +16427,15 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 381,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "C" : {
                     "id" : 370,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16457,11 +16457,11 @@
             "input" : {
                 "A" : {
                     "id" : 369,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 433,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16483,11 +16483,11 @@
             "input" : {
                 "A" : {
                     "id" : 49,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 381,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16509,11 +16509,11 @@
             "input" : [
                 {
                     "id" : 368,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 377,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -16533,7 +16533,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16555,7 +16555,7 @@
             "input" : {
                 "A" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 5
@@ -16579,15 +16579,15 @@
             "input" : [
                 {
                     "id" : 375,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 39,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 353,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -16604,11 +16604,11 @@
             "input" : {
                 "A" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 287,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16630,11 +16630,11 @@
             "input" : {
                 "A" : {
                     "id" : 318,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16656,11 +16656,11 @@
       "input": {
         "A": {
           "id": 318,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -16682,11 +16682,11 @@
       "input": {
         "A": {
           "id": 318,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -16708,11 +16708,11 @@
       "input": [
         {
           "id": 265,
-          "damage": 32767
+          "damage": -1
         },
         {
           "id": 318,
-          "damage": 32767
+          "damage": -1
                 }
             ],
             "output" : [
@@ -16729,7 +16729,7 @@
             "input" : {
                 "A" : {
                     "id" : 336,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16750,7 +16750,7 @@
       "input": {
         "A": {
           "id": 4,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -16772,7 +16772,7 @@
       "input": {
         "A": {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -16794,7 +16794,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16816,7 +16816,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16838,7 +16838,7 @@
             "input" : {
                 "A" : {
                     "id" : 348,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16859,7 +16859,7 @@
             "input" : {
                 "A" : {
                     "id" : 266,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16881,7 +16881,7 @@
             "input" : {
                 "A" : {
                     "id" : 41,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16902,7 +16902,7 @@
             "input" : {
                 "A" : {
                     "id" : 371,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16924,7 +16924,7 @@
             "input" : {
                 "A" : {
                     "id" : 266,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16945,11 +16945,11 @@
             "input" : {
                 "A" : {
                     "id" : 266,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 260,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16971,11 +16971,11 @@
             "input" : {
                 "A" : {
                     "id" : 266,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -16997,7 +16997,7 @@
             "input" : {
                 "A" : {
                     "id" : 266,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -17018,11 +17018,11 @@
             "input" : {
                 "A" : {
                     "id" : 371,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 391,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -17044,7 +17044,7 @@
             "input" : {
                 "A" : {
                     "id" : 266,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -17066,7 +17066,7 @@
             "input" : {
                 "A" : {
                     "id" : 266,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -17087,11 +17087,11 @@
             "input" : {
                 "A" : {
                     "id" : 266,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -17113,7 +17113,7 @@
             "input" : {
                 "A" : {
                     "id" : 266,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -17135,11 +17135,11 @@
             "input" : {
                 "A" : {
                     "id" : 266,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -17161,15 +17161,15 @@
             "input" : {
                 "A" : {
                     "id" : 266,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "C" : {
                     "id" : 331,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -17192,11 +17192,11 @@
             "input" : {
                 "A" : {
                     "id" : 266,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -17218,11 +17218,11 @@
             "input" : {
                 "A" : {
                     "id" : 266,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -17248,7 +17248,7 @@
                 },
                 {
                     "id" : 406,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -17316,7 +17316,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -17404,19 +17404,19 @@
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -17525,7 +17525,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -17576,7 +17576,7 @@
             "input" : {
                 "A" : {
                     "id" : 102,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -17604,7 +17604,7 @@
             "input" : {
                 "A" : {
                     "id" : 172,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -17636,7 +17636,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -17724,19 +17724,19 @@
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -17755,7 +17755,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -17806,7 +17806,7 @@
             "input" : {
                 "A" : {
                     "id" : 102,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -17834,7 +17834,7 @@
             "input" : {
                 "A" : {
                     "id" : 172,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -17862,7 +17862,7 @@
             "input" : {
                 "A" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : -166,
@@ -17870,7 +17870,7 @@
                 },
                 "C" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -17891,15 +17891,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 44,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -17920,15 +17920,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 182,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -17949,15 +17949,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -162,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -17978,15 +17978,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -166,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -18007,15 +18007,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 44,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -18036,15 +18036,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 182,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -18065,15 +18065,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -162,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -18094,15 +18094,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -166,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -18123,7 +18123,7 @@
       "input": {
         "A": {
           "id": 296,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -18145,7 +18145,7 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18165,7 +18165,7 @@
             "input" : {
                 "A" : {
                     "id" : 737,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18190,23 +18190,23 @@
             "input" : [
                 {
                     "id" : -220,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 374,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 374,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 374,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 374,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -18224,7 +18224,7 @@
             "input" : {
                 "A" : {
                     "id" : 737,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18248,7 +18248,7 @@
             "input" : {
                 "A" : {
                     "id" : 736,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18269,11 +18269,11 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 54,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18295,11 +18295,11 @@
             "input" : {
                 "A" : {
                     "id" : 410,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 328,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18320,11 +18320,11 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18346,7 +18346,7 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18368,7 +18368,7 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18390,7 +18390,7 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18411,7 +18411,7 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18433,7 +18433,7 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18456,7 +18456,7 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18477,11 +18477,11 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18503,7 +18503,7 @@
             "input" : {
                 "A" : {
                     "id" : 42,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18524,7 +18524,7 @@
             "input" : {
                 "A" : {
                     "id" : 452,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18546,7 +18546,7 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18568,7 +18568,7 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18589,11 +18589,11 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18615,11 +18615,11 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18641,11 +18641,11 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18667,7 +18667,7 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18688,11 +18688,11 @@
             "input" : {
                 "A" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 334,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18714,11 +18714,11 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 264,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -18740,11 +18740,11 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 264,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -18770,7 +18770,7 @@
         },
         "B": {
           "id": 269,
-          "damage": 32767
+          "damage": -1
         }
             },
             "output" : [
@@ -18819,7 +18819,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -18842,7 +18842,7 @@
             "input" : {
                 "A" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 5,
@@ -18889,7 +18889,7 @@
             "input" : {
                 "A" : {
                     "id" : -7,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -19001,7 +19001,7 @@
             "input" : {
                 "A" : {
                     "id" : -7,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -19046,7 +19046,7 @@
             "input" : {
                 "A" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -19069,11 +19069,11 @@
             "input" : {
                 "A" : {
                     "id" : 452,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 50,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -19117,7 +19117,7 @@
             "input" : {
                 "A" : {
                     "id" : 22,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -19139,11 +19139,11 @@
             "input" : {
                 "A" : {
                     "id" : 287,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 341,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -19166,7 +19166,7 @@
             "input" : {
                 "A" : {
                     "id" : 415,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -19187,7 +19187,7 @@
             "input" : {
                 "A" : {
                     "id" : 334,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -19208,7 +19208,7 @@
             "input" : {
                 "A" : {
                     "id" : 334,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -19230,7 +19230,7 @@
             "input" : {
                 "A" : {
                     "id" : 334,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -19251,7 +19251,7 @@
             "input" : {
                 "A" : {
                     "id" : 334,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -19273,7 +19273,7 @@
             "input" : {
                 "A" : {
                     "id" : 334,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -19295,11 +19295,11 @@
             "input" : {
                 "A" : {
                     "id" : 158,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 47,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -19321,11 +19321,11 @@
       "input": {
         "A": {
           "id": -264,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 47,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -19347,11 +19347,11 @@
       "input": {
         "A": {
           "id": -265,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 47,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -19373,11 +19373,11 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 4,
-          "damage": 32767
+          "damage": -1
                 }
             },
             "output" : [
@@ -19402,7 +19402,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -19490,19 +19490,19 @@
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -19631,7 +19631,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -19682,7 +19682,7 @@
             "input" : {
                 "A" : {
                     "id" : 102,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -19710,7 +19710,7 @@
             "input" : {
                 "A" : {
                     "id" : 172,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -19769,7 +19769,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -19830,19 +19830,19 @@
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -20067,7 +20067,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -20118,7 +20118,7 @@
             "input" : {
                 "A" : {
                     "id" : 102,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -20146,7 +20146,7 @@
             "input" : {
                 "A" : {
                     "id" : 172,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -20174,7 +20174,7 @@
             "input" : {
                 "A" : {
                     "id" : 266,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -20225,7 +20225,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -20286,19 +20286,19 @@
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -20363,7 +20363,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -20414,7 +20414,7 @@
             "input" : {
                 "A" : {
                     "id" : 102,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -20442,7 +20442,7 @@
             "input" : {
                 "A" : {
                     "id" : 172,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -20470,11 +20470,11 @@
             "input" : {
                 "A" : {
                     "id" : -155,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 50,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -20495,11 +20495,11 @@
             "input" : {
                 "A" : {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 345,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -20526,7 +20526,7 @@
         },
         "B": {
           "id": 742,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -20548,11 +20548,11 @@
       "input": {
         "A": {
           "id": 287,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -20573,11 +20573,11 @@
       "input": {
         "A": {
           "id": 287,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -20602,7 +20602,7 @@
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
                 }
             },
             "output" : [
@@ -20690,19 +20690,19 @@
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -20959,7 +20959,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -21010,7 +21010,7 @@
             "input" : {
                 "A" : {
                     "id" : 102,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -21038,7 +21038,7 @@
             "input" : {
                 "A" : {
                     "id" : 172,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -21066,7 +21066,7 @@
             "input" : {
                 "A" : {
                     "id" : 378,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -21087,11 +21087,11 @@
             "input" : [
                 {
                     "id" : 377,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 341,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -21108,7 +21108,7 @@
             "input" : {
                 "A" : {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -21130,7 +21130,7 @@
             "input" : {
                 "A" : {
                     "id" : 360,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -21152,7 +21152,7 @@
             "input" : {
                 "A" : {
                     "id" : 360,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -21172,7 +21172,7 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -21193,11 +21193,11 @@
             "input" : [
                 {
                     "id" : 4,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 106,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -21214,7 +21214,7 @@
             "input" : {
                 "A" : {
                     "id" : 48,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -21237,7 +21237,7 @@
             "input" : {
                 "A" : {
                     "id" : 48,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -21309,7 +21309,7 @@
                 },
                 {
                     "id" : 106,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -21327,15 +21327,15 @@
             "input" : [
                 {
                     "id" : 39,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 40,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 281,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -21352,7 +21352,7 @@
             "input" : {
                 "A" : {
                     "id" : 405,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -21373,11 +21373,11 @@
             "input" : {
                 "A" : {
                     "id" : 112,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 405,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -21399,7 +21399,7 @@
             "input" : {
                 "A" : {
                     "id" : 112,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -21422,7 +21422,7 @@
             "input" : {
                 "A" : {
                     "id" : 112,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -21445,7 +21445,7 @@
             "input" : {
                 "A" : {
                     "id" : 372,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -21467,7 +21467,7 @@
       "input": {
         "A": {
           "id": 742,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -21489,35 +21489,35 @@
       "input": [
         {
           "id": 752,
-          "damage": 32767
+          "damage": -1
         },
         {
           "id": 752,
-          "damage": 32767
+          "damage": -1
         },
         {
           "id": 752,
-          "damage": 32767
+          "damage": -1
         },
         {
           "id": 752,
-          "damage": 32767
+          "damage": -1
         },
         {
           "id": 266,
-          "damage": 32767
+          "damage": -1
         },
         {
           "id": 266,
-          "damage": 32767
+          "damage": -1
         },
         {
           "id": 266,
-          "damage": 32767
+          "damage": -1
         },
         {
           "id": 266,
-          "damage": 32767
+          "damage": -1
         }
       ],
       "output": [
@@ -21534,7 +21534,7 @@
       "input": {
         "A": {
           "id": -270,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -21555,11 +21555,11 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 331,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -21581,11 +21581,11 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 331,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -21627,7 +21627,7 @@
             "input" : {
                 "A" : {
                     "id" : -10,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -21732,7 +21732,7 @@
             "input" : {
                 "A" : {
                     "id" : -10,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -21775,15 +21775,15 @@
             "input" : {
                 "A" : {
                     "id" : 4,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 331,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "C" : {
                     "id" : 406,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -21809,7 +21809,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -21897,19 +21897,19 @@
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -21969,7 +21969,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -22020,7 +22020,7 @@
             "input" : {
                 "A" : {
                     "id" : 102,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -22048,7 +22048,7 @@
             "input" : {
                 "A" : {
                     "id" : 172,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -22076,7 +22076,7 @@
             "input" : {
                 "A" : {
                     "id" : 79,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -22098,7 +22098,7 @@
             "input" : {
                 "A" : {
                     "id" : 338,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -22145,7 +22145,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -22233,19 +22233,19 @@
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -22347,7 +22347,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -22398,7 +22398,7 @@
             "input" : {
                 "A" : {
                     "id" : 102,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -22426,7 +22426,7 @@
             "input" : {
                 "A" : {
                     "id" : 172,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -22454,19 +22454,19 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 4,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": 265,
-          "damage": 32767
+          "damage": -1
         },
         "D": {
           "id": 331,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -22488,19 +22488,19 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 4,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": 265,
-          "damage": 32767
+          "damage": -1
         },
         "D": {
           "id": 331,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -22568,7 +22568,7 @@
       "input": {
         "A": {
           "id": -234,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -22590,7 +22590,7 @@
       "input": {
         "A": {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -22612,7 +22612,7 @@
       "input": {
         "A": {
           "id": -274,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -22633,7 +22633,7 @@
       "input": {
         "A": {
           "id": -274,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -22656,7 +22656,7 @@
       "input": {
         "A": {
           "id": -274,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -22678,7 +22678,7 @@
       "input": {
         "A": {
           "id": -291,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -22700,7 +22700,7 @@
       "input": {
         "A": {
           "id": -291,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -22720,7 +22720,7 @@
       "input": {
         "A": {
           "id": -291,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -22740,7 +22740,7 @@
       "input": {
         "A": {
           "id": -291,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -22761,7 +22761,7 @@
       "input": {
         "A": {
           "id": -291,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -22784,7 +22784,7 @@
       "input": {
         "A": {
           "id": -291,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -22898,7 +22898,7 @@
             "input" : {
                 "A" : {
                     "id" : 409,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -22919,7 +22919,7 @@
             "input" : {
                 "A" : {
                     "id" : 409,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -23032,15 +23032,15 @@
             "input" : [
                 {
                     "id" : 86,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 353,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 344,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -23057,7 +23057,7 @@
             "input" : {
                 "A" : {
                     "id" : 86,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -23082,7 +23082,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -23170,19 +23170,19 @@
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -23247,7 +23247,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -23298,7 +23298,7 @@
             "input" : {
                 "A" : {
                     "id" : 102,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -23326,7 +23326,7 @@
             "input" : {
                 "A" : {
                     "id" : 172,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -23354,7 +23354,7 @@
             "input" : {
                 "A" : {
                     "id" : 433,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -23376,7 +23376,7 @@
             "input" : {
                 "A" : {
                     "id" : 201,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -23399,7 +23399,7 @@
           "input": {
             "A": {
               "id": 406,
-              "damage": 32767
+              "damage": -1
             }
           },
           "output": [
@@ -23462,23 +23462,23 @@
             "input" : [
                 {
                     "id" : 281,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 393,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 391,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 39,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 412,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -23495,23 +23495,23 @@
             "input" : [
                 {
                     "id" : 281,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 393,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 391,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 40,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 412,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -23528,11 +23528,11 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -23559,7 +23559,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -23647,19 +23647,19 @@
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -23678,7 +23678,7 @@
             "input" : [
                 {
                     "id" : 457,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -23750,11 +23750,11 @@
             "input" : {
                 "A" : {
                     "id" : 405,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 372,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -23775,7 +23775,7 @@
             "input" : {
                 "A" : {
                     "id" : 215,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -23798,7 +23798,7 @@
             "input" : {
                 "A" : {
                     "id" : 215,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -23886,7 +23886,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -23937,7 +23937,7 @@
             "input" : {
                 "A" : {
                     "id" : 102,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -23965,7 +23965,7 @@
             "input" : {
                 "A" : {
                     "id" : 172,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -23993,7 +23993,7 @@
             "input" : {
                 "A" : {
                     "id" : 152,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24014,7 +24014,7 @@
             "input" : {
                 "A" : {
                     "id" : 331,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24036,11 +24036,11 @@
             "input" : {
                 "A" : {
                     "id" : 331,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 89,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24062,11 +24062,11 @@
             "input" : {
                 "A" : {
                     "id" : 331,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24087,11 +24087,11 @@
             "input" : {
                 "A" : {
                     "id" : 76,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 331,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "C" : {
                     "id" : 1
@@ -24115,11 +24115,11 @@
       "input": {
         "A": {
           "id": -289,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 89,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -24205,11 +24205,11 @@
             "input" : {
                 "A" : {
                     "id" : -163,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 287,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24232,11 +24232,11 @@
             "input" : {
                 "A" : {
                     "id" : 409,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 422,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24258,7 +24258,7 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24279,11 +24279,11 @@
             "input" : {
                 "A" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24305,11 +24305,11 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 265,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -24331,11 +24331,11 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 265,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -24357,11 +24357,11 @@
       "input": {
         "A": {
           "id": 445,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 54,
-          "damage": 32767
+          "damage": -1
                 }
             },
             "output" : [
@@ -24387,7 +24387,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24414,7 +24414,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24441,7 +24441,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24468,7 +24468,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24494,7 +24494,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24521,7 +24521,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24544,7 +24544,7 @@
             "input" : {
                 "A" : {
                     "id" : 341,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24566,7 +24566,7 @@
             "input" : {
                 "A" : {
                     "id" : 165,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24587,11 +24587,11 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24613,11 +24613,11 @@
       "input": {
         "A": {
           "id": 265,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -24639,11 +24639,11 @@
       "input": {
         "A": {
           "id": 265,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -24665,11 +24665,11 @@
       "input": {
         "A": {
           "id": 17,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 61,
-          "damage": 32767
+          "damage": -1
                 }
             },
             "output" : [
@@ -24691,11 +24691,11 @@
       "input": {
         "A": {
           "id": -225,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 61,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -24717,11 +24717,11 @@
       "input": {
         "A": {
           "id": 162,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 61,
-          "damage": 32767
+          "damage": -1
                 }
             },
             "output" : [
@@ -24743,11 +24743,11 @@
             "input" : {
                 "A" : {
                     "id" : -8,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 61,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24769,11 +24769,11 @@
             "input" : {
                 "A" : {
                     "id" : -6,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 61,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24795,11 +24795,11 @@
       "input": {
         "A": {
           "id": -240,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 61,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -24821,11 +24821,11 @@
       "input": {
         "A": {
           "id": -9,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 61,
-          "damage": 32767
+          "damage": -1
                 }
             },
             "output" : [
@@ -24847,11 +24847,11 @@
             "input" : {
                 "A" : {
                     "id" : -7,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 61,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24873,11 +24873,11 @@
             "input" : {
                 "A" : {
                     "id" : -10,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 61,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24899,11 +24899,11 @@
             "input" : {
                 "A" : {
                     "id" : -5,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 61,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -24925,11 +24925,11 @@
       "input": {
         "A": {
           "id": -241,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 61,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -24951,11 +24951,11 @@
       "input": {
         "A": {
           "id": -226,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 61,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25090,7 +25090,7 @@
             "input" : {
                 "A" : {
                     "id" : 332,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -25111,7 +25111,7 @@
             "input" : {
                 "A" : {
                     "id" : 80,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -25132,15 +25132,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -236,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -225,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25162,15 +25162,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 88,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -225,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25192,15 +25192,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 88,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": 17,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25222,15 +25222,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 88,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": 162,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25252,15 +25252,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 88,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -8,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25282,15 +25282,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 88,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -6,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25312,15 +25312,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 88,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -9,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25342,15 +25342,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 88,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -7,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25372,15 +25372,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 88,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -10,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25402,15 +25402,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 88,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -5,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25432,15 +25432,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 88,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -212,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25462,15 +25462,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -236,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": 17,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25492,15 +25492,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -236,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": 162,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25522,15 +25522,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -236,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -8,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25552,15 +25552,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -236,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -6,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25582,15 +25582,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -236,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -9,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25612,15 +25612,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -236,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -7,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25642,15 +25642,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -236,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -10,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25672,15 +25672,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -236,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -5,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25702,15 +25702,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -236,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -212,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25732,15 +25732,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -236,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -240,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25762,15 +25762,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 88,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -240,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25792,15 +25792,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -236,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -241,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25822,15 +25822,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 88,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -241,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25852,15 +25852,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -236,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -226,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25882,15 +25882,15 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 88,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -226,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25912,11 +25912,11 @@
       "input": {
         "A": {
           "id": 452,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -268,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25938,15 +25938,15 @@
       "input": {
         "A": {
           "id": 263,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": 88,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -25969,15 +25969,15 @@
       "input": {
         "A": {
           "id": 263,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -236,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -26000,11 +26000,11 @@
       "input": {
         "A": {
           "id": 371,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 360,
-          "damage": 32767
+          "damage": -1
                 }
             },
             "output" : [
@@ -26030,7 +26030,7 @@
                 },
                 "B" : {
                   "id": 269,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -26079,7 +26079,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -26102,7 +26102,7 @@
             "input" : {
                 "A" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 5,
@@ -26149,7 +26149,7 @@
             "input" : {
                 "A" : {
                     "id" : -5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -26261,7 +26261,7 @@
             "input" : {
                 "A" : {
                     "id" : -5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -26306,7 +26306,7 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -26328,7 +26328,7 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -26350,11 +26350,11 @@
       "input": {
         "A": {
           "id": 341,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 33,
-          "damage": 32767
+          "damage": -1
                 }
             },
             "output" : [
@@ -26376,11 +26376,11 @@
       "input": {
         "A": {
           "id": 4,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -26402,11 +26402,11 @@
       "input": {
         "A": {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -26491,11 +26491,11 @@
       "input": {
         "A": {
           "id": 4,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -26517,11 +26517,11 @@
       "input": {
         "A": {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -26543,11 +26543,11 @@
       "input": {
         "A": {
           "id": 4,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -26569,11 +26569,11 @@
       "input": {
         "A": {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -26614,11 +26614,11 @@
       "input": {
         "A": {
           "id": 4,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -26640,11 +26640,11 @@
       "input": {
         "A": {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -26688,11 +26688,11 @@
       "input": {
         "A": {
           "id": 4,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -26714,11 +26714,11 @@
       "input": {
         "A": {
           "id": -273,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -26761,11 +26761,11 @@
             "input" : {
                 "A" : {
                     "id" : 265,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 1,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -26786,7 +26786,7 @@
             "input" : {
               "A": {
                 "id": 287,
-                "damage": 32767
+                "damage": -1
               }
             },
           "output": [
@@ -26807,7 +26807,7 @@
       "input": {
         "A": {
           "id": -240,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -26829,7 +26829,7 @@
       "input": {
         "A": {
           "id": -241,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -26851,7 +26851,7 @@
             "input" : {
                 "A" : {
                     "id" : 338,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -26871,15 +26871,15 @@
             "input" : [
                 {
                     "id" : 39,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 40,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 281,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 38,
@@ -26901,15 +26901,15 @@
             "input" : [
                 {
                     "id" : 39,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 40,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 281,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 38,
@@ -26931,15 +26931,15 @@
             "input" : [
                 {
                     "id" : 39,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 40,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 281,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 38,
@@ -26961,15 +26961,15 @@
             "input" : [
                 {
                     "id" : 39,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 40,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 281,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 38,
@@ -26991,19 +26991,19 @@
             "input" : [
                 {
                     "id" : 39,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 40,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 281,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 37,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -27021,15 +27021,15 @@
             "input" : [
                 {
                     "id" : 39,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 40,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 281,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 38,
@@ -27051,15 +27051,15 @@
             "input" : [
                 {
                     "id" : 39,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 40,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 281,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 38,
@@ -27081,15 +27081,15 @@
             "input" : [
                 {
                     "id" : 39,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 40,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 281,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 38
@@ -27109,15 +27109,15 @@
             "input" : [
                 {
                     "id" : 39,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 40,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 281,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 38,
@@ -27139,15 +27139,15 @@
             "input" : [
                 {
                     "id" : 39,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 40,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 281,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 38,
@@ -27169,15 +27169,15 @@
             "input" : [
                 {
                     "id" : 39,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 40,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 281,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 38,
@@ -27199,15 +27199,15 @@
             "input" : [
                 {
                     "id" : 39,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 40,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 281,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 38,
@@ -27229,19 +27229,19 @@
             "input" : [
                 {
                     "id" : 39,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 40,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 281,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : -216,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
           "output": [
@@ -27259,11 +27259,11 @@
       "input": {
         "A": {
           "id": 331,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 170,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -27285,11 +27285,11 @@
       "input": {
         "A": {
           "id": 289,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 12,
-          "damage": 32767
+          "damage": -1
                 }
             },
             "output" : [
@@ -27314,7 +27314,7 @@
                 },
                 "B" : {
                     "id" : 328,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -27335,11 +27335,11 @@
             "input" : [
                 {
                     "id" : 54,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 131,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
           "output": [
@@ -27356,15 +27356,15 @@
       "input": {
         "A": {
           "id": 265,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -27386,15 +27386,15 @@
       "input": {
         "A": {
           "id": 265,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "C": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -27416,7 +27416,7 @@
       "input": {
         "A": {
           "id": 468,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -27437,7 +27437,7 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -27457,7 +27457,7 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -27480,11 +27480,11 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -27506,11 +27506,11 @@
       "input": {
         "A": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -27531,11 +27531,11 @@
       "input": {
         "A": {
           "id": 346,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": -229,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -27556,7 +27556,7 @@
       "input": {
         "A": {
           "id": -226,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -27578,7 +27578,7 @@
       "input": {
         "A": {
           "id": -226,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -27599,7 +27599,7 @@
       "input": {
         "A": {
           "id": -241,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -27620,7 +27620,7 @@
       "input": {
         "A": {
           "id": -301,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -27641,7 +27641,7 @@
       "input": {
         "A": {
           "id": -298,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -27662,7 +27662,7 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -27682,11 +27682,11 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -27709,7 +27709,7 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -27730,7 +27730,7 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -27753,7 +27753,7 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -27775,7 +27775,7 @@
       "input": {
         "A": {
           "id": 170,
-          "damage": 32767
+          "damage": -1
                 }
             },
             "output" : [
@@ -27799,7 +27799,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -27858,19 +27858,19 @@
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -27904,19 +27904,19 @@
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -27970,7 +27970,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -27997,7 +27997,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -28045,7 +28045,7 @@
             "input" : {
                 "A" : {
                     "id" : 102,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -28072,7 +28072,7 @@
             "input" : {
                 "A" : {
                     "id" : 172,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -28099,7 +28099,7 @@
             "input" : {
                 "A" : {
                     "id" : 172,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -28126,11 +28126,11 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -28152,11 +28152,11 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -28200,11 +28200,11 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -28226,11 +28226,11 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -28252,11 +28252,11 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -28278,11 +28278,11 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -28304,11 +28304,11 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -28330,11 +28330,11 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -28356,11 +28356,11 @@
       "input": {
         "A": {
           "id": -242,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -28382,11 +28382,11 @@
       "input": {
         "A": {
           "id": -243,
-          "damage": 32767
+          "damage": -1
         },
         "B": {
           "id": 280,
-          "damage": 32767
+          "damage": -1
         }
       },
       "output": [
@@ -28408,14 +28408,14 @@
       "input": [
         {
           "id": 340,
-          "damage": 32767
+          "damage": -1
         },
         {
           "id": 351
         },
                 {
                     "id" : 288,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -28436,7 +28436,7 @@
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -28524,19 +28524,19 @@
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 13,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -28590,7 +28590,7 @@
             "input" : {
                 "A" : {
                     "id" : 20,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -28641,7 +28641,7 @@
             "input" : {
                 "A" : {
                     "id" : 102,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -28669,7 +28669,7 @@
             "input" : {
                 "A" : {
                     "id" : 172,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 351,
@@ -28719,15 +28719,15 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 402,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -28746,15 +28746,15 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 402,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -28773,15 +28773,15 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 402,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -28800,15 +28800,15 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 402,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -28827,15 +28827,15 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 402,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -28854,15 +28854,15 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 402,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -28881,15 +28881,15 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 402,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -28908,15 +28908,15 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 402,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -28935,15 +28935,15 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 402,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -28962,15 +28962,15 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 402,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -28989,15 +28989,15 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 402,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -29016,15 +29016,15 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 402,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -29043,15 +29043,15 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 402,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -29070,15 +29070,15 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 402,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -29097,15 +29097,15 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 402,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -29124,15 +29124,15 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 402,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -29151,15 +29151,15 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 402,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -29178,15 +29178,15 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 402,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -29205,15 +29205,15 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 402,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -29232,15 +29232,15 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 402,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -29259,7 +29259,7 @@
             "input" : [
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 351
@@ -29280,7 +29280,7 @@
             "input" : [
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 351,
@@ -29303,7 +29303,7 @@
             "input" : [
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 351,
@@ -29326,7 +29326,7 @@
             "input" : [
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 351,
@@ -29349,7 +29349,7 @@
             "input" : [
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 351,
@@ -29372,7 +29372,7 @@
             "input" : [
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 351,
@@ -29395,7 +29395,7 @@
             "input" : [
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 351,
@@ -29418,7 +29418,7 @@
             "input" : [
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 351,
@@ -29440,7 +29440,7 @@
             "input" : [
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 351,
@@ -29463,7 +29463,7 @@
             "input" : [
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 351,
@@ -29486,7 +29486,7 @@
             "input" : [
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 351,
@@ -29509,7 +29509,7 @@
             "input" : [
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 351,
@@ -29532,7 +29532,7 @@
             "input" : [
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 351,
@@ -29555,7 +29555,7 @@
             "input" : [
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 351,
@@ -29578,7 +29578,7 @@
             "input" : [
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 351,
@@ -29601,7 +29601,7 @@
             "input" : [
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 351,
@@ -29624,7 +29624,7 @@
             "input" : [
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 351,
@@ -29647,7 +29647,7 @@
             "input" : [
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 351,
@@ -29670,7 +29670,7 @@
             "input" : [
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 351,
@@ -29693,7 +29693,7 @@
             "input" : [
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 351,
@@ -29716,11 +29716,11 @@
             "input" : [
                 {
                     "id" : 339,
-                  "damage": 32767
+                  "damage": -1
                 },
                 {
                     "id" : 289,
-                  "damage": 32767
+                  "damage": -1
                 }
             ],
             "output" : [
@@ -36740,7 +36740,7 @@
             "input" : {
                 "A" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -37216,11 +37216,11 @@
             "input" : {
                 "A" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -37242,11 +37242,11 @@
             "input" : {
                 "A" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -37268,11 +37268,11 @@
             "input" : {
                 "A" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -37294,11 +37294,11 @@
             "input" : {
                 "A" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [
@@ -38350,11 +38350,11 @@
             "input" : {
                 "A" : {
                     "id" : 5,
-                  "damage": 32767
+                  "damage": -1
                 },
                 "B" : {
                     "id" : 280,
-                  "damage": 32767
+                  "damage": -1
                 }
             },
             "output" : [

--- a/src/main/resources/runtime_item_ids.json
+++ b/src/main/resources/runtime_item_ids.json
@@ -1,1171 +1,1303 @@
 [
     {
-        "name" : "minecraft:item.reeds",
-        "id" : 83
+        "name": "minecraft:purpur_block",
+        "id": 201
     },
     {
-        "name" : "minecraft:air",
-        "id" : -158
+        "name": "minecraft:bow",
+        "id": 261
     },
     {
-        "name" : "minecraft:item.birch_door",
-        "id" : 194
+        "name": "minecraft:end_bricks",
+        "id": 206
     },
     {
-        "name" : "minecraft:apple",
-        "id" : 260
+        "name": "minecraft:air",
+        "id": -158
     },
     {
-        "name" : "minecraft:cooked_porkchop",
-        "id" : 320
+        "name": "minecraft:element_94",
+        "id": -105
     },
     {
-        "name" : "minecraft:beacon",
-        "id" : 138
+        "name": "minecraft:rabbit",
+        "id": 411
     },
     {
-        "name" : "minecraft:stone_stairs",
-        "id" : 67
+        "name": "minecraft:element_25",
+        "id": -36
     },
     {
-        "name" : "minecraft:appleenchanted",
-        "id" : 466
+        "name": "minecraft:mushroom_stew",
+        "id": 282
     },
     {
-        "name" : "minecraft:tripwire",
-        "id" : 132
+        "name": "minecraft:polished_blackstone_brick_slab",
+        "id": -284
     },
     {
-        "name" : "minecraft:leather_leggings",
-        "id" : 300
+        "name": "minecraft:cooked_porkchop",
+        "id": 320
     },
     {
-        "name" : "minecraft:bread",
-        "id" : 297
+        "name": "minecraft:record_ward",
+        "id": 509
     },
     {
-        "name" : "minecraft:light_block",
-        "id" : -215
+        "name": "minecraft:appleenchanted",
+        "id": 466
     },
     {
-        "name" : "minecraft:porkchop",
-        "id" : 319
+        "name": "minecraft:pumpkin",
+        "id": 86
     },
     {
-        "name" : "minecraft:spruce_fence_gate",
-        "id" : 183
+        "name": "minecraft:slime",
+        "id": 165
     },
     {
-        "name" : "minecraft:fish",
-        "id" : 349
+        "name": "minecraft:apple",
+        "id": 260
     },
     {
-        "name" : "minecraft:element_52",
-        "id" : -63
+        "name": "minecraft:element_50",
+        "id": -61
     },
     {
-        "name" : "minecraft:diamond_sword",
-        "id" : 276
+        "name": "minecraft:stripped_oak_log",
+        "id": -10
     },
     {
-        "name" : "minecraft:element_38",
-        "id" : -49
+        "name": "minecraft:golden_apple",
+        "id": 322
     },
     {
-        "name" : "minecraft:sandstone_stairs",
-        "id" : 128
+        "name": "minecraft:fish",
+        "id": 349
     },
     {
-        "name" : "minecraft:acacia_sign",
-        "id" : 475
+        "name": "minecraft:item.dark_oak_door",
+        "id": 197
     },
     {
-        "name" : "minecraft:rabbit_stew",
-        "id" : 413
+        "name": "minecraft:light_block",
+        "id": -215
     },
     {
-        "name" : "minecraft:birch_sign",
-        "id" : 473
+        "name": "minecraft:yellow_glazed_terracotta",
+        "id": 224
     },
     {
-        "name" : "minecraft:horsearmorgold",
-        "id" : 418
+        "name": "minecraft:stone_brick_stairs",
+        "id": 109
     },
     {
-        "name" : "minecraft:element_74",
-        "id" : -85
+        "name": "minecraft:portal",
+        "id": 90
     },
     {
-        "name" : "minecraft:pufferfish",
-        "id" : 462
+        "name": "minecraft:gold_ingot",
+        "id": 266
     },
     {
-        "name" : "minecraft:redstone_block",
-        "id" : 152
+        "name": "minecraft:iron_ingot",
+        "id": 265
     },
     {
-        "name" : "minecraft:golden_apple",
-        "id" : 322
+        "name": "minecraft:cookie",
+        "id": 357
     },
     {
-        "name" : "minecraft:item.wooden_door",
-        "id" : 64
+        "name": "minecraft:porkchop",
+        "id": 319
     },
     {
-        "name" : "minecraft:emerald",
-        "id" : 388
+        "name": "minecraft:bread",
+        "id": 297
     },
     {
-        "name" : "minecraft:element_47",
-        "id" : -58
+        "name": "minecraft:element_7",
+        "id": -18
     },
     {
-        "name" : "minecraft:mushroom_stew",
-        "id" : 282
+        "name": "minecraft:diamond_block",
+        "id": 57
     },
     {
-        "name" : "minecraft:stone_axe",
-        "id" : 275
+        "name": "minecraft:iron_pickaxe",
+        "id": 257
+    },
+    {
+        "name": "minecraft:element_27",
+        "id": -38
+    },
+    {
+        "name": "minecraft:beef",
+        "id": 363
     },
     {
         "name" : "minecraft:salmon",
         "id" : 460
     },
     {
-        "name" : "minecraft:feather",
-        "id" : 288
+        "name": "minecraft:melon",
+        "id": 360
     },
     {
-        "name" : "minecraft:clownfish",
-        "id" : 461
+        "name": "minecraft:clownfish",
+        "id": 461
     },
     {
-        "name" : "minecraft:diamond",
-        "id" : 264
+        "name": "minecraft:element_16",
+        "id": -27
     },
     {
-        "name" : "minecraft:cooked_fish",
-        "id" : 350
+        "name": "minecraft:tripwire",
+        "id": 132
     },
     {
-        "name" : "minecraft:element_32",
-        "id" : -43
+        "name": "minecraft:stone_axe",
+        "id": 275
     },
     {
-        "name" : "minecraft:double_stone_slab4",
-        "id" : -166
+        "name": "minecraft:stained_glass_pane",
+        "id": 160
     },
     {
-        "name" : "minecraft:element_5",
-        "id" : -16
+        "name": "minecraft:trapped_chest",
+        "id": 146
     },
     {
-        "name" : "minecraft:element_25",
-        "id" : -36
+        "name": "minecraft:pufferfish",
+        "id": 462
     },
     {
-        "name" : "minecraft:polished_granite_stairs",
-        "id" : -172
+        "name": "minecraft:bucket",
+        "id": 325
     },
     {
-        "name" : "minecraft:bowl",
-        "id" : 281
+        "name": "minecraft:ancient_debris",
+        "id": -271
     },
     {
-        "name" : "minecraft:red_mushroom_block",
-        "id" : 100
+        "name": "minecraft:anvil",
+        "id": 145
     },
     {
-        "name" : "minecraft:mossy_stone_brick_stairs",
-        "id" : -175
+        "name": "minecraft:stick",
+        "id": 280
     },
     {
-        "name" : "minecraft:cooked_salmon",
-        "id" : 463
+        "name": "minecraft:cooked_fish",
+        "id": 350
     },
     {
-        "name" : "minecraft:element_87",
-        "id" : -98
+        "name": "minecraft:cooked_salmon",
+        "id": 463
     },
     {
-        "name" : "minecraft:pumpkin_seeds",
-        "id" : 361
+        "name": "minecraft:element_61",
+        "id": -72
     },
     {
-        "name" : "minecraft:element_53",
-        "id" : -64
+        "name": "minecraft:sparkler",
+        "id": 442
+    },
+    {
+        "name": "minecraft:warped_door",
+        "id": 756
     },
     {
         "name" : "minecraft:dried_kelp",
         "id" : 464
     },
     {
-        "name" : "minecraft:brewingstandblock",
-        "id" : 117
+        "name": "minecraft:hay_block",
+        "id": 170
     },
     {
-        "name" : "minecraft:wooden_pickaxe",
-        "id" : 270
+        "name": "minecraft:wooden_shovel",
+        "id": 269
     },
     {
-        "name" : "minecraft:cookie",
-        "id" : 357
+        "name": "minecraft:nautilus_shell",
+        "id": 465
     },
     {
-        "name" : "minecraft:gold_ingot",
-        "id" : 266
+        "name": "minecraft:element_1",
+        "id": -12
     },
     {
-        "name" : "minecraft:sweet_berries",
-        "id" : 477
+        "name": "minecraft:stonecutter_block",
+        "id": -197
     },
     {
-        "name" : "minecraft:melon",
-        "id" : 360
+        "name": "minecraft:cooked_beef",
+        "id": 364
     },
     {
-        "name" : "minecraft:iron_pickaxe",
-        "id" : 257
+        "name": "minecraft:comparator",
+        "id": 404
     },
     {
-        "name" : "minecraft:glow_stick",
-        "id" : 166
+        "name": "minecraft:carrot",
+        "id": 391
     },
     {
-        "name" : "minecraft:beef",
-        "id" : 363
+        "name": "minecraft:command_block",
+        "id": 137
     },
     {
-        "name" : "minecraft:stone_hoe",
-        "id" : 291
+        "name": "minecraft:chicken",
+        "id": 365
     },
     {
-        "name" : "minecraft:cooked_beef",
-        "id" : 364
+        "name": "minecraft:potion",
+        "id": 373
     },
     {
-        "name" : "minecraft:lime_glazed_terracotta",
-        "id" : 225
+        "name": "minecraft:rotten_flesh",
+        "id": 367
     },
     {
-        "name" : "minecraft:chicken",
-        "id" : 365
+        "name": "minecraft:dirt",
+        "id": 3
     },
     {
-        "name" : "minecraft:element_31",
-        "id" : -42
+        "name": "minecraft:element_62",
+        "id": -73
     },
     {
-        "name" : "minecraft:cooked_chicken",
-        "id" : 366
+        "name": "minecraft:daylight_detector",
+        "id": 151
     },
     {
-        "name" : "minecraft:rotten_flesh",
-        "id" : 367
+        "name": "minecraft:snow_layer",
+        "id": 78
     },
     {
-        "name" : "minecraft:darkoak_sign",
-        "id" : 476
+        "name": "minecraft:rabbit_foot",
+        "id": 414
     },
     {
-        "name" : "minecraft:stone_sword",
-        "id" : 272
+        "name": "minecraft:lingering_potion",
+        "id": 441
     },
     {
-        "name" : "minecraft:spider_eye",
-        "id" : 375
+        "name": "minecraft:campfire",
+        "id": 720
     },
     {
-        "name" : "minecraft:diamond_axe",
-        "id" : 279
+        "name": "minecraft:smoker",
+        "id": -198
     },
     {
-        "name" : "minecraft:element_105",
-        "id" : -116
+        "name": "minecraft:warped_fence",
+        "id": -257
     },
     {
-        "name" : "minecraft:carrot",
-        "id" : 391
+        "name": "minecraft:cooked_chicken",
+        "id": 366
     },
     {
-        "name" : "minecraft:stripped_birch_log",
-        "id" : -6
+        "name": "minecraft:light_blue_glazed_terracotta",
+        "id": 223
     },
     {
-        "name" : "minecraft:potato",
-        "id" : 392
+        "name": "minecraft:stone_sword",
+        "id": 272
     },
     {
-        "name" : "minecraft:baked_potato",
-        "id" : 393
+        "name": "minecraft:record_far",
+        "id": 504
     },
     {
-        "name" : "minecraft:element_15",
-        "id" : -26
+        "name": "minecraft:spider_eye",
+        "id": 375
     },
     {
-        "name" : "minecraft:carpet",
-        "id" : 171
+        "name": "minecraft:smooth_quartz_stairs",
+        "id": -185
     },
     {
-        "name" : "minecraft:poisonous_potato",
-        "id" : 394
+        "name": "minecraft:potato",
+        "id": 392
     },
     {
-        "name" : "minecraft:beetroot_seeds",
-        "id" : 458
+        "name": "minecraft:baked_potato",
+        "id": 393
     },
     {
-        "name" : "minecraft:noteblock",
-        "id" : 25
+        "name": "minecraft:element_88",
+        "id": -99
     },
     {
-        "name" : "minecraft:golden_carrot",
-        "id" : 396
+        "name": "minecraft:golden_carrot",
+        "id": 396
     },
     {
-        "name" : "minecraft:pumpkin_pie",
-        "id" : 400
+        "name": "minecraft:spruce_stairs",
+        "id": 134
     },
     {
-        "name" : "minecraft:beetroot",
-        "id" : 457
+        "name": "minecraft:poisonous_potato",
+        "id": 394
     },
     {
-        "name" : "minecraft:coral_fan_dead",
-        "id" : -134
+        "name": "minecraft:element_13",
+        "id": -24
     },
     {
-        "name" : "minecraft:iron_ingot",
-        "id" : 265
+        "name": "minecraft:obsidian",
+        "id": 49
     },
     {
-        "name" : "minecraft:beetroot_soup",
-        "id" : 459
+        "name": "minecraft:pumpkin_pie",
+        "id": 400
     },
     {
-        "name" : "minecraft:rabbit",
-        "id" : 411
+        "name": "minecraft:diamond_pickaxe",
+        "id": 278
     },
     {
-        "name" : "minecraft:cooked_rabbit",
-        "id" : 412
+        "name": "minecraft:lantern",
+        "id": -208
     },
     {
-        "name" : "minecraft:iron_helmet",
-        "id" : 306
+        "name": "minecraft:iron_sword",
+        "id": 267
     },
     {
-        "name" : "minecraft:wheat_seeds",
-        "id" : 295
+        "name": "minecraft:smooth_stone",
+        "id": -183
     },
     {
-        "name" : "minecraft:melon_seeds",
-        "id" : 362
+        "name": "minecraft:beetroot",
+        "id": 457
     },
     {
-        "name" : "minecraft:nether_wart",
-        "id" : 372
+        "name": "minecraft:element_43",
+        "id": -54
     },
     {
-        "name" : "minecraft:record_strad",
-        "id" : 508
+        "name": "minecraft:beetroot_soup",
+        "id": 459
     },
     {
-        "name" : "minecraft:iron_sword",
-        "id" : 267
+        "name": "minecraft:red_mushroom",
+        "id": 40
+    },
+    {
+        "name": "minecraft:wooden_pickaxe",
+        "id": 270
+    },
+    {
+        "name": "minecraft:invisiblebedrock",
+        "id": 95
+    },
+    {
+        "name": "minecraft:sweet_berries",
+        "id": 477
+    },
+    {
+        "name": "minecraft:prismarine_bricks_stairs",
+        "id": -4
+    },
+    {
+        "name": "minecraft:cooked_rabbit",
+        "id": 412
+    },
+    {
+        "name": "minecraft:rabbit_stew",
+        "id": 413
+    },
+    {
+        "name": "minecraft:birch_fence_gate",
+        "id": 184
+    },
+    {
+        "name": "minecraft:wheat_seeds",
+        "id": 295
+    },
+    {
+        "name": "minecraft:chest",
+        "id": 54
+    },
+    {
+        "name": "minecraft:pumpkin_seeds",
+        "id": 361
+    },
+    {
+        "name": "minecraft:element_2",
+        "id": -13
+    },
+    {
+        "name": "minecraft:item.crimson_door",
+        "id": -244
+    },
+    {
+        "name": "minecraft:command_block_minecart",
+        "id": 443
+    },
+    {
+        "name": "minecraft:melon_seeds",
+        "id": 362
+    },
+    {
+        "name": "minecraft:iron_axe",
+        "id": 258
+    },
+    {
+        "name": "minecraft:spawn_egg",
+        "id": 383
+    },
+    {
+        "name": "minecraft:element_93",
+        "id": -104
+    },
+    {
+        "name": "minecraft:nether_wart",
+        "id": 372
+    },
+    {
+        "name": "minecraft:beetroot_seeds",
+        "id": 458
+    },
+    {
+        "name": "minecraft:element_35",
+        "id": -46
     },
     {
         "name" : "minecraft:iron_shovel",
         "id" : 256
     },
     {
-        "name" : "minecraft:stone_pickaxe",
-        "id" : 274
+        "name": "minecraft:element_104",
+        "id": -115
     },
     {
-        "name" : "minecraft:leather",
-        "id" : 334
+        "name": "minecraft:granite_stairs",
+        "id": -169
     },
     {
-        "name" : "minecraft:command_block_minecart",
-        "id" : 443
+        "name": "minecraft:flint_and_steel",
+        "id": 259
     },
     {
-        "name" : "minecraft:stone_shovel",
-        "id" : 273
+        "name": "minecraft:stone_shovel",
+        "id": 273
     },
     {
-        "name" : "minecraft:written_book",
-        "id" : 387
+        "name": "minecraft:horsearmorleather",
+        "id": 416
     },
     {
-        "name" : "minecraft:diorite_stairs",
-        "id" : -170
+        "name": "minecraft:item.cauldron",
+        "id": 118
     },
     {
-        "name" : "minecraft:arrow",
-        "id" : 262
+        "name": "minecraft:melon_block",
+        "id": 103
     },
     {
-        "name" : "minecraft:element_97",
-        "id" : -108
+        "name": "minecraft:arrow",
+        "id": 262
     },
     {
-        "name" : "minecraft:campfire",
-        "id" : 720
+        "name": "minecraft:coal",
+        "id": 263
     },
     {
-        "name" : "minecraft:polished_andesite_stairs",
-        "id" : -174
+        "name": "minecraft:real_double_stone_slab2",
+        "id": 181
     },
     {
-        "name" : "minecraft:acacia_stairs",
-        "id" : 163
+        "name": "minecraft:chorus_plant",
+        "id": 240
     },
     {
-        "name" : "minecraft:iron_axe",
-        "id" : 258
+        "name": "minecraft:gold_block",
+        "id": 41
     },
     {
-        "name" : "minecraft:flint_and_steel",
-        "id" : 259
+        "name": "minecraft:carrots",
+        "id": 141
     },
     {
-        "name" : "minecraft:bow",
-        "id" : 261
+        "name": "minecraft:diamond",
+        "id": 264
     },
     {
-        "name" : "minecraft:nautilus_shell",
-        "id" : 465
+        "name": "minecraft:wooden_sword",
+        "id": 268
     },
     {
-        "name" : "minecraft:coal",
-        "id" : 263
+        "name": "minecraft:record_strad",
+        "id": 508
     },
     {
-        "name" : "minecraft:bookshelf",
-        "id" : 47
+        "name": "minecraft:netherite_boots",
+        "id": 751
     },
     {
-        "name" : "minecraft:wooden_sword",
-        "id" : 268
+        "name": "minecraft:dark_oak_stairs",
+        "id": 164
     },
     {
-        "name" : "minecraft:diamond_pickaxe",
-        "id" : 278
+        "name": "minecraft:farmland",
+        "id": 60
     },
     {
-        "name" : "minecraft:deadbush",
-        "id" : 32
+        "name": "minecraft:wooden_axe",
+        "id": 271
     },
     {
-        "name" : "minecraft:ender_chest",
-        "id" : 130
+        "name": "minecraft:stone_pickaxe",
+        "id": 274
     },
     {
-        "name" : "minecraft:record_stal",
-        "id" : 507
+        "name": "minecraft:planks",
+        "id": 5
     },
     {
-        "name" : "minecraft:wooden_shovel",
-        "id" : 269
+        "name": "minecraft:chainmail_helmet",
+        "id": 302
     },
     {
-        "name" : "minecraft:dark_oak_trapdoor",
-        "id" : -147
+        "name": "minecraft:diamond_shovel",
+        "id": 277
     },
     {
-        "name" : "minecraft:record_mall",
-        "id" : 505
+        "name": "minecraft:diamond_sword",
+        "id": 276
     },
     {
-        "name" : "minecraft:wooden_axe",
-        "id" : 271
+        "name": "minecraft:smithing_table",
+        "id": -202
     },
     {
-        "name" : "minecraft:powered_comparator",
-        "id" : 150
+        "name": "minecraft:diamond_axe",
+        "id": 279
     },
     {
-        "name" : "minecraft:diamond_shovel",
-        "id" : 277
+        "name": "minecraft:bowl",
+        "id": 281
     },
     {
-        "name" : "minecraft:golden_rail",
-        "id" : 27
+        "name": "minecraft:flowing_water",
+        "id": 8
     },
     {
-        "name" : "minecraft:lit_furnace",
-        "id" : 62
+        "name": "minecraft:golden_sword",
+        "id": 283
     },
     {
-        "name" : "minecraft:stick",
-        "id" : 280
+        "name": "minecraft:honey_block",
+        "id": -220
     },
     {
-        "name" : "minecraft:slime_ball",
-        "id" : 341
+        "name": "minecraft:golden_shovel",
+        "id": 284
     },
     {
-        "name" : "minecraft:element_58",
-        "id" : -69
+        "name": "minecraft:golden_pickaxe",
+        "id": 285
     },
     {
-        "name" : "minecraft:golden_sword",
-        "id" : 283
+        "name": "minecraft:lit_redstone_lamp",
+        "id": 124
     },
     {
-        "name" : "minecraft:golden_shovel",
-        "id" : 284
+        "name": "minecraft:elytra",
+        "id": 444
     },
     {
-        "name" : "minecraft:chest",
-        "id" : 54
+        "name": "minecraft:golden_axe",
+        "id": 286
     },
     {
-        "name" : "minecraft:golden_pickaxe",
-        "id" : 285
+        "name": "minecraft:element_52",
+        "id": -63
     },
     {
-        "name" : "minecraft:golden_axe",
-        "id" : 286
+        "name": "minecraft:string",
+        "id": 287
     },
     {
-        "name" : "minecraft:element_62",
-        "id" : -73
+        "name": "minecraft:real_double_stone_slab4",
+        "id": -168
     },
     {
-        "name" : "minecraft:string",
-        "id" : 287
+        "name": "minecraft:feather",
+        "id": 288
     },
     {
-        "name" : "minecraft:glowstone_dust",
-        "id" : 348
+        "name": "minecraft:gunpowder",
+        "id": 289
     },
     {
-        "name" : "minecraft:gunpowder",
-        "id" : 289
-    },
-    {
-        "name" : "minecraft:spawn_egg",
-        "id" : 383
-    },
-    {
-        "name" : "minecraft:fence",
-        "id" : 85
+        "name": "minecraft:acacia_stairs",
+        "id": 163
     },
     {
         "name" : "minecraft:wooden_hoe",
         "id" : 290
     },
     {
-        "name" : "minecraft:shulker_shell",
-        "id" : 445
+        "name": "minecraft:stone_hoe",
+        "id": 291
     },
     {
-        "name" : "minecraft:iron_hoe",
-        "id" : 292
+        "name": "minecraft:iron_hoe",
+        "id": 292
     },
     {
-        "name" : "minecraft:diamond_hoe",
-        "id" : 293
+        "name": "minecraft:diamond_hoe",
+        "id": 293
     },
     {
-        "name" : "minecraft:golden_hoe",
-        "id" : 294
+        "name": "minecraft:element_86",
+        "id": -97
     },
     {
-        "name" : "minecraft:turtle_shell_piece",
-        "id" : 468
+        "name": "minecraft:golden_hoe",
+        "id": 294
     },
     {
-        "name" : "minecraft:sweet_berry_bush",
-        "id" : -207
+        "name": "minecraft:wheat",
+        "id": 296
     },
     {
-        "name" : "minecraft:info_update2",
-        "id" : 249
+        "name": "minecraft:leather_helmet",
+        "id": 298
     },
     {
-        "name" : "minecraft:muttoncooked",
-        "id" : 424
+        "name": "minecraft:leather_chestplate",
+        "id": 299
     },
     {
-        "name" : "minecraft:wheat",
-        "id" : 296
+        "name": "minecraft:leather_leggings",
+        "id": 300
     },
     {
-        "name" : "minecraft:dark_oak_door",
-        "id" : 431
+        "name": "minecraft:lodestone",
+        "id": -222
     },
     {
-        "name" : "minecraft:grindstone",
-        "id" : -195
+        "name": "minecraft:brown_mushroom",
+        "id": 39
     },
     {
-        "name" : "minecraft:element_46",
-        "id" : -57
+        "name": "minecraft:leather_boots",
+        "id": 301
     },
     {
-        "name" : "minecraft:potion",
-        "id" : 373
+        "name": "minecraft:chainmail_chestplate",
+        "id": 303
     },
     {
-        "name" : "minecraft:wither_rose",
-        "id" : -216
+        "name": "minecraft:end_gateway",
+        "id": 209
     },
     {
-        "name" : "minecraft:leather_helmet",
-        "id" : 298
-    },
-    {
-        "name" : "minecraft:element_48",
-        "id" : -59
-    },
-    {
-        "name" : "minecraft:leather_chestplate",
-        "id" : 299
-    },
-    {
-        "name" : "minecraft:leather_boots",
-        "id" : 301
-    },
-    {
-        "name" : "minecraft:lectern",
-        "id" : -194
-    },
-    {
-        "name" : "minecraft:smithing_table",
-        "id" : -202
-    },
-    {
-        "name" : "minecraft:bedrock",
-        "id" : 7
-    },
-    {
-        "name" : "minecraft:chainmail_helmet",
-        "id" : 302
-    },
-    {
-        "name" : "minecraft:stonebrick",
-        "id" : 98
-    },
-    {
-        "name" : "minecraft:stickypistonarmcollision",
-        "id" : -217
-    },
-    {
-        "name" : "minecraft:structure_void",
-        "id" : 217
-    },
-    {
-        "name" : "minecraft:chainmail_chestplate",
-        "id" : 303
-    },
-    {
-        "name" : "minecraft:lit_blast_furnace",
-        "id" : -214
-    },
-    {
-        "name" : "minecraft:element_11",
-        "id" : -22
+        "name": "minecraft:item.beetroot",
+        "id": 244
     },
     {
         "name" : "minecraft:chainmail_leggings",
         "id" : 304
     },
     {
-        "name" : "minecraft:saddle",
-        "id" : 329
+        "name": "minecraft:element_101",
+        "id": -112
     },
     {
-        "name" : "minecraft:purpur_block",
-        "id" : 201
+        "name": "minecraft:chainmail_boots",
+        "id": 305
     },
     {
-        "name" : "minecraft:chainmail_boots",
-        "id" : 305
+        "name": "minecraft:soul_sand",
+        "id": 88
     },
     {
-        "name" : "minecraft:ladder",
-        "id" : 65
+        "name": "minecraft:iron_helmet",
+        "id": 306
     },
     {
-        "name" : "minecraft:iron_chestplate",
-        "id" : 307
+        "name": "minecraft:snowball",
+        "id": 332
     },
     {
-        "name" : "minecraft:diamond_helmet",
-        "id" : 310
+        "name": "minecraft:element_49",
+        "id": -60
     },
     {
-        "name" : "minecraft:iron_leggings",
-        "id" : 308
+        "name": "minecraft:record_mellohi",
+        "id": 506
     },
     {
-        "name" : "minecraft:iron_boots",
-        "id" : 309
+        "name": "minecraft:iron_chestplate",
+        "id": 307
     },
     {
-        "name" : "minecraft:element_104",
-        "id" : -115
+        "name": "minecraft:barrel",
+        "id": -203
     },
     {
-        "name" : "minecraft:chorus_fruit_popped",
-        "id" : 433
+        "name": "minecraft:iron_leggings",
+        "id": 308
     },
     {
-        "name" : "minecraft:diamond_chestplate",
-        "id" : 311
+        "name": "minecraft:crimson_double_slab",
+        "id": -266
     },
     {
-        "name" : "minecraft:diamond_leggings",
-        "id" : 312
+        "name": "minecraft:iron_boots",
+        "id": 309
     },
     {
-        "name" : "minecraft:element_75",
-        "id" : -86
+        "name": "minecraft:real_double_stone_slab3",
+        "id": -167
     },
     {
-        "name" : "minecraft:diamond_boots",
-        "id" : 313
+        "name": "minecraft:ender_eye",
+        "id": 381
     },
     {
-        "name" : "minecraft:acacia_button",
-        "id" : -140
+        "name": "minecraft:stickypistonarmcollision",
+        "id": -217
     },
     {
-        "name" : "minecraft:standing_banner",
-        "id" : 176
+        "name": "minecraft:iron_trapdoor",
+        "id": 167
     },
     {
-        "name" : "minecraft:golden_helmet",
-        "id" : 314
+        "name": "minecraft:diamond_helmet",
+        "id": 310
     },
     {
-        "name" : "minecraft:golden_chestplate",
-        "id" : 315
+        "name": "minecraft:stone_pressure_plate",
+        "id": 70
     },
     {
-        "name" : "minecraft:golden_leggings",
-        "id" : 316
+        "name": "minecraft:diamond_chestplate",
+        "id": 311
     },
     {
-        "name" : "minecraft:golden_boots",
-        "id" : 317
+        "name": "minecraft:sand",
+        "id": 12
     },
     {
-        "name" : "minecraft:item.hopper",
-        "id" : 154
+        "name": "minecraft:light_weighted_pressure_plate",
+        "id": 147
     },
     {
-        "name" : "minecraft:shield",
-        "id" : 513
+        "name": "minecraft:piston",
+        "id": 33
     },
     {
-        "name" : "minecraft:flint",
-        "id" : 318
+        "name": "minecraft:diamond_leggings",
+        "id": 312
     },
     {
-        "name" : "minecraft:painting",
-        "id" : 321
+        "name": "minecraft:element_30",
+        "id": -41
     },
     {
-        "name" : "minecraft:sign",
-        "id" : 323
+        "name": "minecraft:diamond_boots",
+        "id": 313
     },
     {
-        "name" : "minecraft:wooden_door",
-        "id" : 324
+        "name": "minecraft:golden_helmet",
+        "id": 314
     },
     {
-        "name" : "minecraft:bucket",
-        "id" : 325
+        "name": "minecraft:element_51",
+        "id": -62
     },
     {
-        "name" : "minecraft:minecart",
-        "id" : 328
+        "name": "minecraft:double_wooden_slab",
+        "id": 157
     },
     {
-        "name" : "minecraft:prismarine_stairs",
-        "id" : -2
+        "name": "minecraft:hard_stained_glass",
+        "id": 254
     },
     {
-        "name" : "minecraft:iron_door",
-        "id" : 330
+        "name": "minecraft:element_84",
+        "id": -95
     },
     {
-        "name" : "minecraft:tripwire_hook",
-        "id" : 131
+        "name": "minecraft:golden_chestplate",
+        "id": 315
     },
     {
-        "name" : "minecraft:redstone",
-        "id" : 331
+        "name": "minecraft:sealantern",
+        "id": 169
     },
     {
-        "name" : "minecraft:andesite_stairs",
-        "id" : -171
+        "name": "minecraft:bedrock",
+        "id": 7
     },
     {
-        "name" : "minecraft:sponge",
-        "id" : 19
+        "name": "minecraft:glowstone",
+        "id": 89
     },
     {
-        "name" : "minecraft:snowball",
-        "id" : 332
+        "name": "minecraft:golden_leggings",
+        "id": 316
     },
     {
-        "name" : "minecraft:boat",
-        "id" : 333
+        "name": "minecraft:golden_boots",
+        "id": 317
     },
     {
-        "name" : "minecraft:item.dark_oak_door",
-        "id" : 197
+        "name": "minecraft:shield",
+        "id": 513
     },
     {
-        "name" : "minecraft:kelp",
-        "id" : 335
+        "name": "minecraft:jungle_fence_gate",
+        "id": 185
     },
     {
-        "name" : "minecraft:brick",
-        "id" : 336
+        "name": "minecraft:carpet",
+        "id": 171
     },
     {
-        "name" : "minecraft:clay_ball",
-        "id" : 337
+        "name": "minecraft:flowing_lava",
+        "id": 10
     },
     {
-        "name" : "minecraft:real_double_stone_slab",
-        "id" : 43
+        "name": "minecraft:flint",
+        "id": 318
     },
     {
-        "name" : "minecraft:reeds",
-        "id" : 338
+        "name": "minecraft:painting",
+        "id": 321
     },
     {
-        "name" : "minecraft:dirt",
-        "id" : 3
+        "name": "minecraft:heart_of_the_sea",
+        "id": 467
     },
     {
-        "name" : "minecraft:magma",
-        "id" : 213
+        "name": "minecraft:sign",
+        "id": 323
     },
     {
-        "name" : "minecraft:red_mushroom",
-        "id" : 40
+        "name": "minecraft:muttonraw",
+        "id": 423
     },
     {
-        "name" : "minecraft:paper",
-        "id" : 339
+        "name": "minecraft:element_55",
+        "id": -66
     },
     {
-        "name" : "minecraft:book",
-        "id" : 340
+        "name": "minecraft:wooden_door",
+        "id": 324
     },
     {
-        "name" : "minecraft:chest_minecart",
-        "id" : 342
+        "name": "minecraft:concrete_powder",
+        "id": 237
     },
     {
-        "name" : "minecraft:flowing_lava",
-        "id" : 10
+        "name": "minecraft:minecart",
+        "id": 328
     },
     {
-        "name" : "minecraft:element_86",
-        "id" : -97
+        "name": "minecraft:saddle",
+        "id": 329
     },
     {
-        "name" : "minecraft:red_glazed_terracotta",
-        "id" : 234
+        "name": "minecraft:nether_wart_block",
+        "id": 214
     },
     {
-        "name" : "minecraft:crafting_table",
-        "id" : 58
+        "name": "minecraft:crimson_roots",
+        "id": -223
     },
     {
-        "name" : "minecraft:egg",
-        "id" : 344
+        "name": "minecraft:element_116",
+        "id": -127
     },
     {
-        "name" : "minecraft:real_double_stone_slab4",
-        "id" : -168
+        "name": "minecraft:iron_door",
+        "id": 330
     },
     {
-        "name" : "minecraft:end_gateway",
-        "id" : 209
+        "name": "minecraft:redstone",
+        "id": 331
+    },
+    {
+        "name": "minecraft:boat",
+        "id": 333
+    },
+    {
+        "name": "minecraft:written_book",
+        "id": 387
+    },
+    {
+        "name": "minecraft:iron_ore",
+        "id": 15
+    },
+    {
+        "name": "minecraft:leather",
+        "id": 334
+    },
+    {
+        "name": "minecraft:kelp",
+        "id": 335
+    },
+    {
+        "name": "minecraft:gold_nugget",
+        "id": 371
+    },
+    {
+        "name": "minecraft:brick",
+        "id": 336
+    },
+    {
+        "name": "minecraft:element_68",
+        "id": -79
+    },
+    {
+        "name": "minecraft:clay_ball",
+        "id": 337
+    },
+    {
+        "name": "minecraft:carrotonastick",
+        "id": 398
+    },
+    {
+        "name": "minecraft:reeds",
+        "id": 338
+    },
+    {
+        "name": "minecraft:paper",
+        "id": 339
+    },
+    {
+        "name": "minecraft:element_23",
+        "id": -34
+    },
+    {
+        "name": "minecraft:coral",
+        "id": -131
+    },
+    {
+        "name": "minecraft:book",
+        "id": 340
+    },
+    {
+        "name": "minecraft:end_portal",
+        "id": 119
+    },
+    {
+        "name": "minecraft:trident",
+        "id": 455
+    },
+    {
+        "name": "minecraft:slime_ball",
+        "id": 341
+    },
+    {
+        "name": "minecraft:chest_minecart",
+        "id": 342
+    },
+    {
+        "name": "minecraft:element_71",
+        "id": -82
+    },
+    {
+        "name": "minecraft:egg",
+        "id": 344
+    },
+    {
+        "name": "minecraft:netherite_sword",
+        "id": 743
+    },
+    {
+        "name": "minecraft:item.reeds",
+        "id": 83
     },
     {
         "name" : "minecraft:compass",
         "id" : 345
     },
     {
-        "name" : "minecraft:horsearmordiamond",
-        "id" : 419
+        "name": "minecraft:crimson_stairs",
+        "id": -254
     },
     {
-        "name" : "minecraft:sapling",
-        "id" : 6
+        "name": "minecraft:fishing_rod",
+        "id": 346
     },
     {
-        "name" : "minecraft:fishing_rod",
-        "id" : 346
+        "name": "minecraft:andesite_stairs",
+        "id": -171
     },
     {
-        "name" : "minecraft:name_tag",
-        "id" : 421
+        "name": "minecraft:reserved6",
+        "id": 255
     },
     {
-        "name" : "minecraft:clock",
-        "id" : 347
+        "name": "minecraft:clock",
+        "id": 347
     },
     {
-        "name" : "minecraft:element_96",
-        "id" : -107
+        "name": "minecraft:red_sandstone",
+        "id": 179
     },
     {
-        "name" : "minecraft:dye",
-        "id" : 351
+        "name": "minecraft:spruce_button",
+        "id": -144
     },
     {
-        "name" : "minecraft:anvil",
-        "id" : 145
+        "name": "minecraft:glowstone_dust",
+        "id": 348
     },
     {
-        "name" : "minecraft:conduit",
-        "id" : -157
+        "name": "minecraft:blaze_rod",
+        "id": 369
+    },
+    {
+        "name": "minecraft:dye",
+        "id": 351
+    },
+    {
+        "name": "minecraft:element_74",
+        "id": -85
     },
     {
         "name" : "minecraft:bone",
         "id" : 352
     },
     {
-        "name" : "minecraft:soul_sand",
-        "id" : 88
+        "name": "minecraft:map",
+        "id": 358
     },
     {
-        "name" : "minecraft:sugar",
-        "id" : 353
+        "name": "minecraft:sugar",
+        "id": 353
     },
     {
-        "name" : "minecraft:cake",
-        "id" : 354
+        "name": "minecraft:name_tag",
+        "id": 421
     },
     {
-        "name" : "minecraft:element_113",
-        "id" : -124
+        "name": "minecraft:cake",
+        "id": 354
     },
     {
-        "name" : "minecraft:mossy_cobblestone",
-        "id" : 48
+        "name": "minecraft:bed",
+        "id": 355
     },
     {
-        "name" : "minecraft:bed",
-        "id" : 355
+        "name": "minecraft:stained_glass",
+        "id": 241
     },
     {
-        "name" : "minecraft:flowing_water",
-        "id" : 8
+        "name": "minecraft:repeater",
+        "id": 356
     },
     {
-        "name" : "minecraft:item.frame",
-        "id" : 199
+        "name": "minecraft:beacon",
+        "id": 138
     },
     {
-        "name" : "minecraft:repeater",
-        "id" : 356
+        "name": "minecraft:netherite_chestplate",
+        "id": 749
     },
     {
-        "name" : "minecraft:map",
-        "id" : 358
+        "name": "minecraft:unpowered_comparator",
+        "id": 149
     },
     {
-        "name" : "minecraft:shears",
-        "id" : 359
+        "name": "minecraft:shears",
+        "id": 359
     },
     {
-        "name" : "minecraft:double_stone_slab2",
-        "id" : 182
+        "name": "minecraft:element_31",
+        "id": -42
     },
     {
-        "name" : "minecraft:element_3",
-        "id" : -14
+        "name": "minecraft:ender_pearl",
+        "id": 368
     },
     {
-        "name" : "minecraft:element_23",
-        "id" : -34
+        "name": "minecraft:red_sandstone_stairs",
+        "id": 180
     },
     {
-        "name" : "minecraft:skull",
-        "id" : 397
+        "name": "minecraft:carved_pumpkin",
+        "id": -155
     },
     {
-        "name" : "minecraft:ender_pearl",
-        "id" : 368
+        "name": "minecraft:ghast_tear",
+        "id": 370
     },
     {
-        "name" : "minecraft:carved_pumpkin",
-        "id" : -155
+        "name": "minecraft:glass_bottle",
+        "id": 374
     },
     {
-        "name" : "minecraft:yellow_flower",
-        "id" : 37
+        "name": "minecraft:element_44",
+        "id": -55
     },
     {
-        "name" : "minecraft:shulker_box",
-        "id" : 218
+        "name": "minecraft:lava",
+        "id": 11
     },
     {
-        "name" : "minecraft:blaze_rod",
-        "id" : 369
+        "name": "minecraft:polished_blackstone_brick_stairs",
+        "id": -275
     },
     {
-        "name" : "minecraft:lit_pumpkin",
-        "id" : 91
+        "name": "minecraft:jungle_pressure_plate",
+        "id": -153
     },
     {
-        "name" : "minecraft:ghast_tear",
-        "id" : 370
+        "name": "minecraft:fermented_spider_eye",
+        "id": 376
     },
     {
-        "name" : "minecraft:gold_nugget",
-        "id" : 371
+        "name": "minecraft:honeycomb_block",
+        "id": -221
     },
     {
-        "name" : "minecraft:glass_bottle",
-        "id" : 374
+        "name": "minecraft:blaze_powder",
+        "id": 377
     },
     {
-        "name" : "minecraft:emptymap",
-        "id" : 395
+        "name": "minecraft:magma_cream",
+        "id": 378
     },
     {
-        "name" : "minecraft:fermented_spider_eye",
-        "id" : 376
+        "name": "minecraft:jigsaw",
+        "id": -211
     },
     {
-        "name" : "minecraft:element_81",
-        "id" : -92
+        "name": "minecraft:brewing_stand",
+        "id": 379
     },
     {
-        "name" : "minecraft:monster_egg",
-        "id" : 97
+        "name": "minecraft:cauldron",
+        "id": 380
     },
     {
-        "name" : "minecraft:blaze_powder",
-        "id" : 377
+        "name": "minecraft:element_111",
+        "id": -122
     },
     {
-        "name" : "minecraft:armor_stand",
-        "id" : 425
+        "name": "minecraft:rapid_fertilizer",
+        "id": 449
     },
     {
-        "name" : "minecraft:magma_cream",
-        "id" : 378
+        "name": "minecraft:clay",
+        "id": 82
     },
     {
-        "name" : "minecraft:brewing_stand",
-        "id" : 379
+        "name": "minecraft:speckled_melon",
+        "id": 382
     },
     {
-        "name" : "minecraft:darkoak_standing_sign",
-        "id" : -192
+        "name": "minecraft:experience_bottle",
+        "id": 384
     },
     {
-        "name" : "minecraft:glowingobsidian",
-        "id" : 246
+        "name": "minecraft:element_48",
+        "id": -59
     },
     {
-        "name" : "minecraft:cauldron",
-        "id" : 380
+        "name": "minecraft:coal_block",
+        "id": 173
     },
     {
-        "name" : "minecraft:nether_brick",
-        "id" : 112
+        "name": "minecraft:fireball",
+        "id": 385
     },
     {
-        "name" : "minecraft:ender_eye",
-        "id" : 381
+        "name": "minecraft:writable_book",
+        "id": 386
     },
     {
-        "name" : "minecraft:experience_bottle",
-        "id" : 384
+        "name": "minecraft:element_69",
+        "id": -80
     },
     {
-        "name" : "minecraft:speckled_melon",
-        "id" : 382
+        "name": "minecraft:emerald",
+        "id": 388
     },
     {
-        "name" : "minecraft:coral",
-        "id" : -131
+        "name": "minecraft:record_pigstep",
+        "id": 759
     },
     {
-        "name" : "minecraft:fireball",
-        "id" : 385
+        "name": "minecraft:element_66",
+        "id": -77
     },
     {
-        "name" : "minecraft:writable_book",
-        "id" : 386
+        "name": "minecraft:frame",
+        "id": 389
     },
     {
-        "name" : "minecraft:frame",
-        "id" : 389
+        "name": "minecraft:brewingstandblock",
+        "id": 117
     },
     {
-        "name" : "minecraft:smoker",
-        "id" : -198
+        "name": "minecraft:flower_pot",
+        "id": 390
     },
     {
-        "name" : "minecraft:flower_pot",
-        "id" : 390
+        "name": "minecraft:emptymap",
+        "id": 395
     },
     {
-        "name" : "minecraft:carrotonastick",
-        "id" : 398
+        "name": "minecraft:element_110",
+        "id": -121
     },
     {
-        "name" : "minecraft:netherstar",
-        "id" : 399
+        "name": "minecraft:element_75",
+        "id": -86
     },
     {
-        "name" : "minecraft:element_16",
-        "id" : -27
+        "name": "minecraft:skull",
+        "id": 397
     },
     {
-        "name" : "minecraft:fireworks",
-        "id" : 401
+        "name": "minecraft:crimson_door",
+        "id": 755
     },
     {
-        "name" : "minecraft:element_30",
-        "id" : -41
+        "name": "minecraft:sponge",
+        "id": 19
+    },
+    {
+        "name": "minecraft:netherstar",
+        "id": 399
+    },
+    {
+        "name": "minecraft:fireworks",
+        "id": 401
+    },
+    {
+        "name": "minecraft:hopper_minecart",
+        "id": 408
     },
     {
         "name" : "minecraft:fireworkscharge",
         "id" : 402
     },
     {
-        "name" : "minecraft:trident",
-        "id" : 455
-    },
-    {
         "name" : "minecraft:enchanted_book",
         "id" : 403
-    },
-    {
-        "name" : "minecraft:comparator",
-        "id" : 404
     },
     {
         "name" : "minecraft:netherbrick",
         "id" : 405
     },
     {
-        "name" : "minecraft:concrete",
-        "id" : 236
-    },
-    {
-        "name" : "minecraft:element_73",
-        "id" : -84
+        "name": "minecraft:cobblestone_wall",
+        "id": 139
     },
     {
         "name" : "minecraft:quartz",
@@ -1176,596 +1308,708 @@
         "id" : 407
     },
     {
-        "name" : "minecraft:leaves2",
-        "id" : 161
+        "name": "minecraft:element_63",
+        "id": -74
     },
     {
-        "name" : "minecraft:element_102",
-        "id" : -113
+        "name": "minecraft:hopper",
+        "id": 410
     },
     {
-        "name" : "minecraft:coral_fan_hang2",
-        "id" : -136
+        "name": "minecraft:cobblestone",
+        "id": 4
     },
     {
-        "name" : "minecraft:element_67",
-        "id" : -78
+        "name": "minecraft:dragon_breath",
+        "id": 437
     },
     {
-        "name" : "minecraft:hopper_minecart",
-        "id" : 408
+        "name": "minecraft:rabbit_hide",
+        "id": 415
     },
     {
-        "name" : "minecraft:lead",
-        "id" : 420
+        "name": "minecraft:horsearmoriron",
+        "id": 417
     },
     {
-        "name" : "minecraft:sea_pickle",
-        "id" : -156
+        "name": "minecraft:horsearmorgold",
+        "id": 418
     },
     {
-        "name" : "minecraft:hopper",
-        "id" : 410
+        "name": "minecraft:colored_torch_bp",
+        "id": 204
     },
     {
-        "name" : "minecraft:rabbit_foot",
-        "id" : 414
+        "name": "minecraft:element_102",
+        "id": -113
     },
     {
-        "name" : "minecraft:rabbit_hide",
-        "id" : 415
+        "name": "minecraft:quartz_ore",
+        "id": 153
     },
     {
-        "name" : "minecraft:acacia_standing_sign",
-        "id" : -190
+        "name": "minecraft:netherite_shovel",
+        "id": 744
     },
     {
-        "name" : "minecraft:horsearmorleather",
-        "id" : 416
+        "name": "minecraft:horsearmordiamond",
+        "id": 419
     },
     {
-        "name" : "minecraft:item.wheat",
-        "id" : 59
+        "name": "minecraft:record_13",
+        "id": 500
     },
     {
-        "name" : "minecraft:horsearmoriron",
-        "id" : 417
+        "name": "minecraft:record_cat",
+        "id": 501
     },
     {
-        "name" : "minecraft:record_13",
-        "id" : 500
+        "name": "minecraft:element_3",
+        "id": -14
     },
     {
-        "name" : "minecraft:stone_button",
-        "id" : 77
+        "name": "minecraft:polished_diorite_stairs",
+        "id": -173
     },
     {
-        "name" : "minecraft:record_cat",
-        "id" : 501
+        "name": "minecraft:monster_egg",
+        "id": 97
     },
     {
-        "name" : "minecraft:element_89",
-        "id" : -100
+        "name": "minecraft:record_blocks",
+        "id": 502
     },
     {
-        "name" : "minecraft:record_blocks",
-        "id" : 502
+        "name": "minecraft:crimson_standing_sign",
+        "id": -250
     },
     {
-        "name" : "minecraft:bamboo",
-        "id" : -163
+        "name": "minecraft:record_chirp",
+        "id": 503
     },
     {
-        "name" : "minecraft:element_72",
-        "id" : -83
+        "name": "minecraft:record_mall",
+        "id": 505
     },
     {
-        "name" : "minecraft:record_chirp",
-        "id" : 503
+        "name": "minecraft:respawn_anchor",
+        "id": -272
     },
     {
-        "name" : "minecraft:frosted_ice",
-        "id" : 207
+        "name": "minecraft:record_stal",
+        "id": 507
     },
     {
-        "name" : "minecraft:record_far",
-        "id" : 504
+        "name": "minecraft:record_11",
+        "id": 510
     },
     {
-        "name" : "minecraft:record_wait",
-        "id" : 511
+        "name": "minecraft:record_wait",
+        "id": 511
     },
     {
-        "name" : "minecraft:spruce_door",
-        "id" : 427
+        "name": "minecraft:info_update2",
+        "id": 249
     },
     {
-        "name" : "minecraft:record_mellohi",
-        "id" : 506
+        "name": "minecraft:lead",
+        "id": 420
     },
     {
-        "name" : "minecraft:vine",
-        "id" : 106
+        "name": "minecraft:prismarine_crystals",
+        "id": 422
     },
     {
-        "name" : "minecraft:record_ward",
-        "id" : 509
+        "name": "minecraft:acacia_sign",
+        "id": 475
     },
     {
-        "name" : "minecraft:jungle_stairs",
-        "id" : 136
+        "name": "minecraft:muttoncooked",
+        "id": 424
     },
     {
-        "name" : "minecraft:ice_bomb",
-        "id" : 453
+        "name": "minecraft:armor_stand",
+        "id": 425
     },
     {
-        "name" : "minecraft:record_11",
-        "id" : 510
+        "name": "minecraft:coal_ore",
+        "id": 16
     },
     {
-        "name" : "minecraft:prismarine_crystals",
-        "id" : 422
+        "name": "minecraft:element_32",
+        "id": -43
     },
     {
-        "name" : "minecraft:banner",
-        "id" : 446
+        "name": "minecraft:spruce_door",
+        "id": 427
     },
     {
-        "name" : "minecraft:glass_pane",
-        "id" : 102
+        "name": "minecraft:phantom_membrane",
+        "id": 470
     },
     {
-        "name" : "minecraft:muttonraw",
-        "id" : 423
+        "name": "minecraft:birch_door",
+        "id": 428
     },
     {
-        "name" : "minecraft:end_crystal",
-        "id" : 426
+        "name": "minecraft:element_85",
+        "id": -96
     },
     {
-        "name" : "minecraft:element_55",
-        "id" : -66
+        "name": "minecraft:polished_blackstone_wall",
+        "id": -297
     },
     {
-        "name" : "minecraft:birch_door",
-        "id" : 428
+        "name": "minecraft:jungle_door",
+        "id": 429
     },
     {
-        "name" : "minecraft:darkoak_wall_sign",
-        "id" : -193
+        "name": "minecraft:acacia_door",
+        "id": 430
     },
     {
-        "name" : "minecraft:jungle_door",
-        "id" : 429
+        "name": "minecraft:element_42",
+        "id": -53
     },
     {
-        "name" : "minecraft:acacia_door",
-        "id" : 430
+        "name": "minecraft:dark_oak_door",
+        "id": 431
     },
     {
-        "name" : "minecraft:element_116",
-        "id" : -127
+        "name": "minecraft:netherite_leggings",
+        "id": 750
     },
     {
-        "name" : "minecraft:chorus_fruit",
-        "id" : 432
+        "name": "minecraft:stripped_crimson_stem",
+        "id": -240
     },
     {
-        "name" : "minecraft:cobblestone_wall",
-        "id" : 139
+        "name": "minecraft:chorus_fruit",
+        "id": 432
     },
     {
-        "name" : "minecraft:cobblestone",
-        "id" : 4
+        "name": "minecraft:camera",
+        "id": 498
     },
     {
-        "name" : "minecraft:dragon_breath",
-        "id" : 437
+        "name": "minecraft:suspicious_stew",
+        "id": 734
     },
     {
-        "name" : "minecraft:cactus",
-        "id" : 81
+        "name": "minecraft:chorus_fruit_popped",
+        "id": 433
+    },
+    {
+        "name": "minecraft:element_98",
+        "id": -109
     },
     {
         "name" : "minecraft:splash_potion",
         "id" : 438
     },
     {
-        "name" : "minecraft:spruce_stairs",
-        "id" : 134
+        "name": "minecraft:element_73",
+        "id": -84
     },
     {
-        "name" : "minecraft:loom",
-        "id" : -204
+        "name": "minecraft:prismarine_shard",
+        "id": 409
     },
     {
-        "name" : "minecraft:powered_repeater",
-        "id" : 94
+        "name": "minecraft:seagrass",
+        "id": -130
     },
     {
-        "name" : "minecraft:lingering_potion",
-        "id" : 441
+        "name": "minecraft:dark_oak_pressure_plate",
+        "id": -152
     },
     {
-        "name" : "minecraft:elytra",
-        "id" : 444
+        "name": "minecraft:shulker_shell",
+        "id": 445
     },
     {
-        "name" : "minecraft:prismarine_shard",
-        "id" : 409
+        "name": "minecraft:redstone_block",
+        "id": 152
     },
     {
-        "name" : "minecraft:element_112",
-        "id" : -123
+        "name": "minecraft:banner",
+        "id": 446
     },
     {
-        "name" : "minecraft:totem",
-        "id" : 450
+        "name": "minecraft:totem",
+        "id": 450
     },
     {
-        "name" : "minecraft:iron_nugget",
-        "id" : 452
+        "name": "minecraft:blackstone_slab",
+        "id": -282
     },
     {
-        "name" : "minecraft:pumpkin_stem",
-        "id" : 104
+        "name": "minecraft:element_118",
+        "id": -129
     },
     {
-        "name" : "minecraft:element_50",
-        "id" : -61
+        "name": "minecraft:iron_nugget",
+        "id": 452
     },
     {
-        "name" : "minecraft:lever",
-        "id" : 69
+        "name": "minecraft:netherite_pickaxe",
+        "id": 745
     },
     {
-        "name" : "minecraft:heart_of_the_sea",
-        "id" : 467
+        "name": "minecraft:jukebox",
+        "id": 84
     },
     {
-        "name" : "minecraft:element_92",
-        "id" : -103
+        "name": "minecraft:turtle_shell_piece",
+        "id": 468
     },
     {
-        "name" : "minecraft:grass",
-        "id" : 2
+        "name": "minecraft:turtle_helmet",
+        "id": 469
     },
     {
-        "name" : "minecraft:turtle_helmet",
-        "id" : 469
+        "name": "minecraft:crossbow",
+        "id": 471
     },
     {
-        "name" : "minecraft:wall_banner",
-        "id" : 177
+        "name": "minecraft:glowingobsidian",
+        "id": 246
     },
     {
-        "name" : "minecraft:spruce_button",
-        "id" : -144
+        "name": "minecraft:leaves2",
+        "id": 161
     },
     {
-        "name" : "minecraft:phantom_membrane",
-        "id" : 470
+        "name": "minecraft:spruce_sign",
+        "id": 472
     },
     {
-        "name" : "minecraft:crossbow",
-        "id" : 471
+        "name": "minecraft:element_38",
+        "id": -49
     },
     {
-        "name" : "minecraft:spruce_sign",
-        "id" : 472
+        "name": "minecraft:coral_fan_hang2",
+        "id": -136
     },
     {
-        "name" : "minecraft:quartz_stairs",
-        "id" : 156
+        "name": "minecraft:birch_sign",
+        "id": 473
     },
     {
-        "name" : "minecraft:daylight_detector_inverted",
-        "id" : 178
+        "name": "minecraft:coral_fan_dead",
+        "id": -134
     },
     {
-        "name" : "minecraft:jungle_sign",
-        "id" : 474
+        "name": "minecraft:balloon",
+        "id": 448
     },
     {
-        "name" : "minecraft:red_flower",
-        "id" : 38
+        "name": "minecraft:jungle_sign",
+        "id": 474
     },
     {
-        "name" : "minecraft:tallgrass",
-        "id" : 31
+        "name": "minecraft:darkoak_sign",
+        "id": 476
     },
     {
-        "name" : "minecraft:banner_pattern",
-        "id" : 434
+        "name": "minecraft:element_24",
+        "id": -35
     },
     {
-        "name" : "minecraft:suspicious_stew",
-        "id" : 734
+        "name": "minecraft:banner_pattern",
+        "id": 434
     },
     {
-        "name" : "minecraft:birch_fence_gate",
-        "id" : 184
+        "name": "minecraft:honeycomb",
+        "id": 736
     },
     {
-        "name" : "minecraft:honeycomb",
-        "id" : 736
+        "name": "minecraft:element_78",
+        "id": -89
     },
     {
-        "name" : "minecraft:element_115",
-        "id" : -126
+        "name": "minecraft:red_nether_brick",
+        "id": 215
     },
     {
-        "name" : "minecraft:honey_bottle",
-        "id" : 737
+        "name": "minecraft:honey_bottle",
+        "id": 737
     },
     {
-        "name" : "minecraft:element_4",
-        "id" : -15
+        "name": "minecraft:compound",
+        "id": 499
     },
     {
-        "name" : "minecraft:element_24",
-        "id" : -35
+        "name": "minecraft:ice_bomb",
+        "id": 453
     },
     {
-        "name" : "minecraft:camera",
-        "id" : 498
+        "name": "minecraft:brick_block",
+        "id": 45
     },
     {
-        "name" : "minecraft:compound",
-        "id" : 499
+        "name": "minecraft:bleach",
+        "id": 451
     },
     {
-        "name" : "minecraft:bleach",
-        "id" : 451
+        "name": "minecraft:colored_torch_rg",
+        "id": 202
     },
     {
-        "name" : "minecraft:element_40",
-        "id" : -51
+        "name": "minecraft:medicine",
+        "id": 447
     },
     {
-        "name" : "minecraft:honey_block",
-        "id" : -220
+        "name": "minecraft:warped_fungus",
+        "id": -229
     },
     {
-        "name" : "minecraft:rapid_fertilizer",
-        "id" : 449
+        "name": "minecraft:end_portal_frame",
+        "id": 120
     },
     {
-        "name" : "minecraft:balloon",
-        "id" : 448
+        "name": "minecraft:element_92",
+        "id": -103
     },
     {
-        "name" : "minecraft:redstone_ore",
-        "id" : 73
+        "name": "minecraft:glow_stick",
+        "id": 166
     },
     {
-        "name" : "minecraft:stonecutter_block",
-        "id" : -197
+        "name": "minecraft:lodestonecompass",
+        "id": 741
     },
     {
-        "name" : "minecraft:medicine",
-        "id" : 447
+        "name": "minecraft:element_17",
+        "id": -28
     },
     {
-        "name" : "minecraft:gold_block",
-        "id" : 41
+        "name": "minecraft:lit_pumpkin",
+        "id": 91
     },
     {
-        "name" : "minecraft:stripped_oak_log",
-        "id" : -10
+        "name": "minecraft:netherite_ingot",
+        "id": 742
     },
     {
-        "name" : "minecraft:blue_ice",
-        "id" : -11
+        "name": "minecraft:chain_command_block",
+        "id": 189
     },
     {
-        "name" : "minecraft:sparkler",
-        "id" : 442
+        "name": "minecraft:loom",
+        "id": -204
     },
     {
-        "name" : "minecraft:stone",
-        "id" : 1
+        "name": "minecraft:item.warped_door",
+        "id": -245
     },
     {
-        "name" : "minecraft:sand",
-        "id" : 12
+        "name": "minecraft:netherite_axe",
+        "id": 746
     },
     {
-        "name" : "minecraft:stained_hardened_clay",
-        "id" : 159
+        "name": "minecraft:netherite_hoe",
+        "id": 747
     },
     {
-        "name" : "minecraft:wool",
-        "id" : 35
+        "name": "minecraft:dark_oak_fence_gate",
+        "id": 186
     },
     {
-        "name" : "minecraft:unpowered_comparator",
-        "id" : 149
+        "name": "minecraft:element_115",
+        "id": -126
     },
     {
-        "name" : "minecraft:log",
-        "id" : 17
+        "name": "minecraft:netherite_helmet",
+        "id": 748
     },
     {
-        "name" : "minecraft:item.kelp",
-        "id" : -138
+        "name": "minecraft:element_117",
+        "id": -128
     },
     {
-        "name" : "minecraft:coral_block",
-        "id" : -132
+        "name": "minecraft:netherite_scrap",
+        "id": 752
     },
     {
-        "name" : "minecraft:element_54",
-        "id" : -65
+        "name": "minecraft:crimson_sign",
+        "id": 753
     },
     {
-        "name" : "minecraft:double_stone_slab",
-        "id" : 44
+        "name": "minecraft:concrete",
+        "id": 236
     },
     {
-        "name" : "minecraft:double_stone_slab3",
-        "id" : -162
+        "name": "minecraft:chiseled_nether_bricks",
+        "id": -302
     },
     {
-        "name" : "minecraft:element_2",
-        "id" : -13
+        "name": "minecraft:mob_spawner",
+        "id": 52
     },
     {
-        "name" : "minecraft:element_22",
-        "id" : -33
+        "name": "minecraft:warped_sign",
+        "id": 754
     },
     {
-        "name" : "minecraft:real_double_stone_slab2",
-        "id" : 181
+        "name": "minecraft:chain",
+        "id": 758
     },
     {
-        "name" : "minecraft:real_double_stone_slab3",
-        "id" : -167
+        "name": "minecraft:warped_fungus_on_a_stick",
+        "id": 757
     },
     {
-        "name" : "minecraft:coral_fan",
-        "id" : -133
+        "name": "minecraft:nether_sprouts",
+        "id": 760
     },
     {
-        "name" : "minecraft:leaves",
-        "id" : 18
+        "name": "minecraft:cartography_table",
+        "id": -200
     },
     {
-        "name" : "minecraft:element_10",
-        "id" : -21
+        "name": "minecraft:polished_blackstone_slab",
+        "id": -293
     },
     {
-        "name" : "minecraft:birch_button",
-        "id" : -141
+        "name": "minecraft:soul_campfire",
+        "id": 801
     },
     {
-        "name" : "minecraft:sandstone",
-        "id" : 24
+        "name": "minecraft:stone",
+        "id": 1
     },
     {
-        "name" : "minecraft:red_sandstone",
-        "id" : 179
+        "name": "minecraft:wool",
+        "id": 35
     },
     {
-        "name" : "minecraft:element_91",
-        "id" : -102
+        "name": "minecraft:yellow_flower",
+        "id": 37
     },
     {
-        "name" : "minecraft:wooden_slab",
-        "id" : 158
+        "name": "minecraft:stained_hardened_clay",
+        "id": 159
     },
     {
-        "name" : "minecraft:end_stone",
-        "id" : 121
+        "name": "minecraft:log",
+        "id": 17
     },
     {
-        "name" : "minecraft:double_plant",
-        "id" : 175
+        "name": "minecraft:fence",
+        "id": 85
     },
     {
-        "name" : "minecraft:waterlily",
-        "id" : 111
+        "name": "minecraft:element_53",
+        "id": -64
     },
     {
-        "name" : "minecraft:snow_layer",
-        "id" : 78
+        "name": "minecraft:stonebrick",
+        "id": 98
     },
     {
-        "name" : "minecraft:black_glazed_terracotta",
-        "id" : 235
+        "name": "minecraft:lit_blast_furnace",
+        "id": -214
     },
     {
-        "name" : "minecraft:planks",
-        "id" : 5
+        "name": "minecraft:coral_block",
+        "id": -132
     },
     {
-        "name" : "minecraft:quartz_block",
-        "id" : 155
+        "name": "minecraft:polished_blackstone_bricks",
+        "id": -274
     },
     {
-        "name" : "minecraft:seagrass",
-        "id" : -130
+        "name": "minecraft:double_stone_slab",
+        "id": 44
     },
     {
-        "name" : "minecraft:brown_mushroom_block",
-        "id" : 99
+        "name": "minecraft:element_100",
+        "id": -111
     },
     {
-        "name" : "minecraft:log2",
-        "id" : 162
+        "name": "minecraft:double_stone_slab2",
+        "id": 182
     },
     {
-        "name" : "minecraft:end_portal_frame",
-        "id" : 120
+        "name": "minecraft:fence_gate",
+        "id": 107
     },
     {
-        "name" : "minecraft:lantern",
-        "id" : -208
+        "name": "minecraft:double_stone_slab3",
+        "id": -162
     },
     {
-        "name" : "minecraft:prismarine",
-        "id" : 168
+        "name": "minecraft:rail",
+        "id": 66
     },
     {
-        "name" : "minecraft:sealantern",
-        "id" : 169
+        "name": "minecraft:double_stone_slab4",
+        "id": -166
     },
     {
-        "name" : "minecraft:hard_stained_glass",
-        "id" : 254
+        "name": "minecraft:stripped_acacia_log",
+        "id": -8
     },
     {
-        "name" : "minecraft:concrete_powder",
-        "id" : 237
+        "name": "minecraft:real_double_stone_slab",
+        "id": 43
     },
     {
-        "name" : "minecraft:stained_glass",
-        "id" : 241
+        "name": "minecraft:coral_fan",
+        "id": -133
     },
     {
-        "name" : "minecraft:element_82",
-        "id" : -93
+        "name": "minecraft:sea_pickle",
+        "id": -156
     },
     {
-        "name" : "minecraft:stained_glass_pane",
-        "id" : 160
+        "name": "minecraft:polished_blackstone_button",
+        "id": -296
     },
     {
-        "name" : "minecraft:quartz_ore",
-        "id" : 153
+        "name": "minecraft:element_90",
+        "id": -101
+    },
+    {
+        "name": "minecraft:polished_blackstone_double_slab",
+        "id": -294
+    },
+    {
+        "name": "minecraft:sapling",
+        "id": 6
+    },
+    {
+        "name": "minecraft:leaves",
+        "id": 18
+    },
+    {
+        "name": "minecraft:sandstone",
+        "id": 24
+    },
+    {
+        "name": "minecraft:silver_glazed_terracotta",
+        "id": 228
+    },
+    {
+        "name": "minecraft:wooden_slab",
+        "id": 158
+    },
+    {
+        "name": "minecraft:warped_roots",
+        "id": -224
+    },
+    {
+        "name": "minecraft:element_11",
+        "id": -22
+    },
+    {
+        "name": "minecraft:red_flower",
+        "id": 38
+    },
+    {
+        "name": "minecraft:element_59",
+        "id": -70
+    },
+    {
+        "name": "minecraft:double_plant",
+        "id": 175
+    },
+    {
+        "name": "minecraft:waterlily",
+        "id": 111
+    },
+    {
+        "name": "minecraft:quartz_block",
+        "id": 155
+    },
+    {
+        "name": "minecraft:element_95",
+        "id": -106
+    },
+    {
+        "name": "minecraft:soul_soil",
+        "id": -236
+    },
+    {
+        "name": "minecraft:acacia_pressure_plate",
+        "id": -150
+    },
+    {
+        "name": "minecraft:tallgrass",
+        "id": 31
+    },
+    {
+        "name": "minecraft:brown_mushroom_block",
+        "id": 99
+    },
+    {
+        "name": "minecraft:element_103",
+        "id": -114
+    },
+    {
+        "name": "minecraft:crimson_fungus",
+        "id": -228
+    },
+    {
+        "name": "minecraft:item.frame",
+        "id": 199
+    },
+    {
+        "name": "minecraft:red_mushroom_block",
+        "id": 100
+    },
+    {
+        "name": "minecraft:log2",
+        "id": 162
+    },
+    {
+        "name": "minecraft:conduit",
+        "id": -157
+    },
+    {
+        "name": "minecraft:prismarine",
+        "id": 168
+    },
+    {
+        "name": "minecraft:magma",
+        "id": 213
+    },
+    {
+        "name": "minecraft:element_22",
+        "id": -33
     },
     {
         "name" : "minecraft:undyed_shulker_box",
         "id" : 205
     },
     {
-        "name" : "minecraft:element_107",
-        "id" : -118
+        "name": "minecraft:shulker_box",
+        "id": 218
     },
     {
-        "name" : "minecraft:piston",
-        "id" : 33
+        "name": "minecraft:spruce_standing_sign",
+        "id": -181
     },
     {
-        "name" : "minecraft:sticky_piston",
-        "id" : 29
+        "name": "minecraft:sticky_piston",
+        "id": 29
     },
     {
-        "name" : "minecraft:turtle_egg",
-        "id" : -159
+        "name": "minecraft:element_10",
+        "id": -21
     },
     {
-        "name" : "minecraft:acacia_fence_gate",
-        "id" : 187
+        "name": "minecraft:turtle_egg",
+        "id": -159
     },
     {
-        "name" : "minecraft:colored_torch_bp",
-        "id" : 204
+        "name": "minecraft:bamboo",
+        "id": -163
     },
     {
-        "name" : "minecraft:lava",
-        "id" : 11
+        "name": "minecraft:observer",
+        "id": 251
     },
     {
         "name" : "minecraft:scaffolding",
@@ -1776,244 +2020,200 @@
         "id" : -196
     },
     {
-        "name" : "minecraft:item.cauldron",
-        "id" : 118
-    },
-    {
-        "name" : "minecraft:barrel",
-        "id" : -203
+        "name": "minecraft:grindstone",
+        "id": -195
     },
     {
         "name" : "minecraft:bell",
         "id" : -206
     },
     {
-        "name" : "minecraft:element_42",
-        "id" : -53
+        "name": "minecraft:end_rod",
+        "id": 208
     },
     {
-        "name" : "minecraft:cartography_table",
-        "id" : -200
+        "name": "minecraft:fletching_table",
+        "id": -201
     },
     {
-        "name" : "minecraft:end_rod",
-        "id" : 208
+        "name": "minecraft:item.hopper",
+        "id": 154
     },
     {
-        "name" : "minecraft:fletching_table",
-        "id" : -201
+        "name": "minecraft:wood",
+        "id": -212
     },
     {
-        "name" : "minecraft:wood",
-        "id" : -212
+        "name": "minecraft:chemistry_table",
+        "id": 238
     },
     {
-        "name" : "minecraft:chemistry_table",
-        "id" : 238
+        "name": "minecraft:tnt",
+        "id": 46
     },
     {
-        "name" : "minecraft:element_70",
-        "id" : -81
+        "name": "minecraft:hard_stained_glass_pane",
+        "id": 191
     },
     {
-        "name" : "minecraft:tnt",
-        "id" : 46
+        "name": "minecraft:crimson_slab",
+        "id": -264
     },
     {
-        "name" : "minecraft:hard_stained_glass_pane",
-        "id" : 191
+        "name": "minecraft:element_87",
+        "id": -98
     },
     {
-        "name" : "minecraft:colored_torch_rg",
-        "id" : 202
+        "name": "minecraft:warped_slab",
+        "id": -265
     },
     {
-        "name" : "minecraft:brown_mushroom",
-        "id" : 39
+        "name": "minecraft:element_0",
+        "id": 36
     },
     {
-        "name" : "minecraft:element_0",
-        "id" : 36
+        "name": "minecraft:element_4",
+        "id": -15
     },
     {
-        "name" : "minecraft:element_20",
-        "id" : -31
+        "name": "minecraft:ender_chest",
+        "id": 130
     },
     {
-        "name" : "minecraft:element_1",
-        "id" : -12
-    },
-    {
-        "name" : "minecraft:element_21",
-        "id" : -32
+        "name": "minecraft:element_5",
+        "id": -16
     },
     {
         "name" : "minecraft:element_6",
         "id" : -17
     },
     {
-        "name" : "minecraft:element_26",
-        "id" : -37
-    },
-    {
-        "name" : "minecraft:element_7",
-        "id" : -18
-    },
-    {
-        "name" : "minecraft:element_27",
-        "id" : -38
-    },
-    {
         "name" : "minecraft:element_8",
         "id" : -19
-    },
-    {
-        "name" : "minecraft:element_28",
-        "id" : -39
-    },
-    {
-        "name" : "minecraft:dark_oak_pressure_plate",
-        "id" : -152
     },
     {
         "name" : "minecraft:element_9",
         "id" : -20
     },
     {
-        "name" : "minecraft:element_29",
-        "id" : -40
-    },
-    {
-        "name" : "minecraft:item.spruce_door",
-        "id" : 193
-    },
-    {
         "name" : "minecraft:element_12",
         "id" : -23
-    },
-    {
-        "name" : "minecraft:cyan_glazed_terracotta",
-        "id" : 229
-    },
-    {
-        "name" : "minecraft:element_13",
-        "id" : -24
     },
     {
         "name" : "minecraft:element_14",
         "id" : -25
     },
     {
-        "name" : "minecraft:iron_ore",
-        "id" : 15
+        "name": "minecraft:element_15",
+        "id": -26
     },
     {
-        "name" : "minecraft:element_17",
-        "id" : -28
+        "name": "minecraft:element_18",
+        "id": -29
     },
     {
-        "name" : "minecraft:element_18",
-        "id" : -29
+        "name": "minecraft:element_19",
+        "id": -30
     },
     {
-        "name" : "minecraft:birch_pressure_plate",
-        "id" : -151
+        "name": "minecraft:element_20",
+        "id": -31
     },
     {
-        "name" : "minecraft:element_19",
-        "id" : -30
+        "name": "minecraft:element_21",
+        "id": -32
     },
     {
-        "name" : "minecraft:wooden_pressure_plate",
-        "id" : 72
+        "name": "minecraft:element_26",
+        "id": -37
     },
     {
-        "name" : "minecraft:element_33",
-        "id" : -44
+        "name": "minecraft:element_28",
+        "id": -39
     },
     {
-        "name" : "minecraft:element_34",
-        "id" : -45
+        "name": "minecraft:element_29",
+        "id": -40
     },
     {
-        "name" : "minecraft:element_35",
-        "id" : -46
+        "name": "minecraft:element_33",
+        "id": -44
     },
     {
-        "name" : "minecraft:composter",
-        "id" : -213
+        "name": "minecraft:element_34",
+        "id": -45
     },
     {
-        "name" : "minecraft:element_36",
-        "id" : -47
+        "name": "minecraft:element_36",
+        "id": -47
     },
     {
-        "name" : "minecraft:element_37",
-        "id" : -48
+        "name": "minecraft:ice",
+        "id": 79
     },
     {
-        "name" : "minecraft:element_39",
-        "id" : -50
+        "name": "minecraft:element_37",
+        "id": -48
     },
     {
-        "name" : "minecraft:element_41",
-        "id" : -52
+        "name": "minecraft:element_39",
+        "id": -50
     },
     {
-        "name" : "minecraft:hay_block",
-        "id" : 170
+        "name": "minecraft:element_40",
+        "id": -51
     },
     {
-        "name" : "minecraft:element_43",
-        "id" : -54
+        "name": "minecraft:element_41",
+        "id": -52
     },
     {
-        "name" : "minecraft:lit_redstone_lamp",
-        "id" : 124
+        "name": "minecraft:element_45",
+        "id": -56
     },
     {
-        "name" : "minecraft:element_44",
-        "id" : -55
+        "name": "minecraft:element_46",
+        "id": -57
     },
     {
-        "name" : "minecraft:element_45",
-        "id" : -56
+        "name": "minecraft:netherite_block",
+        "id": -270
     },
     {
-        "name" : "minecraft:element_49",
-        "id" : -60
+        "name": "minecraft:element_47",
+        "id": -58
     },
     {
-        "name" : "minecraft:element_51",
-        "id" : -62
+        "name": "minecraft:element_54",
+        "id": -65
     },
     {
-        "name" : "minecraft:element_56",
-        "id" : -67
+        "name": "minecraft:element_56",
+        "id": -67
     },
     {
-        "name" : "minecraft:element_57",
-        "id" : -68
+        "name": "minecraft:black_glazed_terracotta",
+        "id": 235
     },
     {
-        "name" : "minecraft:element_59",
-        "id" : -70
+        "name": "minecraft:lit_redstone_ore",
+        "id": 74
     },
     {
-        "name" : "minecraft:element_60",
-        "id" : -71
+        "name": "minecraft:crafting_table",
+        "id": 58
     },
     {
-        "name" : "minecraft:dropper",
-        "id" : 125
+        "name": "minecraft:element_57",
+        "id": -68
     },
     {
-        "name" : "minecraft:element_61",
-        "id" : -72
+        "name": "minecraft:element_58",
+        "id": -69
     },
     {
-        "name" : "minecraft:element_63",
-        "id" : -74
+        "name": "minecraft:element_60",
+        "id": -71
     },
     {
         "name" : "minecraft:element_64",
@@ -2024,492 +2224,576 @@
         "id" : -76
     },
     {
-        "name" : "minecraft:coral_fan_hang3",
-        "id" : -137
+        "name": "minecraft:element_67",
+        "id": -78
     },
     {
-        "name" : "minecraft:element_66",
-        "id" : -77
+        "name": "minecraft:element_70",
+        "id": -81
     },
     {
-        "name" : "minecraft:redstone_lamp",
-        "id" : 123
+        "name": "minecraft:element_72",
+        "id": -83
     },
     {
-        "name" : "minecraft:element_68",
-        "id" : -79
+        "name": "minecraft:element_76",
+        "id": -87
     },
     {
-        "name" : "minecraft:spruce_trapdoor",
-        "id" : -149
+        "name": "minecraft:dark_oak_button",
+        "id": -142
     },
     {
-        "name" : "minecraft:purple_glazed_terracotta",
-        "id" : 219
+        "name": "minecraft:element_77",
+        "id": -88
     },
     {
-        "name" : "minecraft:element_69",
-        "id" : -80
+        "name": "minecraft:diorite_stairs",
+        "id": -170
     },
     {
-        "name" : "minecraft:iron_block",
-        "id" : 42
+        "name": "minecraft:redstone_torch",
+        "id": 76
     },
     {
-        "name" : "minecraft:element_71",
-        "id" : -82
+        "name": "minecraft:element_79",
+        "id": -90
     },
     {
-        "name" : "minecraft:element_76",
-        "id" : -87
+        "name": "minecraft:iron_bars",
+        "id": 101
     },
     {
-        "name" : "minecraft:element_77",
-        "id" : -88
+        "name": "minecraft:element_80",
+        "id": -91
     },
     {
-        "name" : "minecraft:water",
-        "id" : 9
+        "name": "minecraft:element_81",
+        "id": -92
     },
     {
-        "name" : "minecraft:element_78",
-        "id" : -89
+        "name": "minecraft:element_82",
+        "id": -93
     },
     {
-        "name" : "minecraft:element_79",
-        "id" : -90
+        "name": "minecraft:underwater_torch",
+        "id": 239
     },
     {
-        "name" : "minecraft:element_80",
-        "id" : -91
+        "name": "minecraft:blue_ice",
+        "id": -11
     },
     {
-        "name" : "minecraft:netherreactor",
-        "id" : 247
+        "name": "minecraft:element_83",
+        "id": -94
     },
     {
-        "name" : "minecraft:element_83",
-        "id" : -94
+        "name": "minecraft:element_89",
+        "id": -100
     },
     {
-        "name" : "minecraft:element_84",
-        "id" : -95
+        "name": "minecraft:element_91",
+        "id": -102
     },
     {
-        "name" : "minecraft:jungle_wall_sign",
-        "id" : -189
+        "name": "minecraft:element_96",
+        "id": -107
     },
     {
-        "name" : "minecraft:end_brick_stairs",
-        "id" : -178
+        "name": "minecraft:element_97",
+        "id": -108
     },
     {
-        "name" : "minecraft:element_85",
-        "id" : -96
-    },
-    {
-        "name" : "minecraft:element_88",
-        "id" : -99
-    },
-    {
-        "name" : "minecraft:element_90",
-        "id" : -101
-    },
-    {
-        "name" : "minecraft:birch_standing_sign",
-        "id" : -186
-    },
-    {
-        "name" : "minecraft:gold_ore",
-        "id" : 14
-    },
-    {
-        "name" : "minecraft:element_93",
-        "id" : -104
-    },
-    {
-        "name" : "minecraft:element_94",
-        "id" : -105
-    },
-    {
-        "name" : "minecraft:element_95",
-        "id" : -106
-    },
-    {
-        "name" : "minecraft:glass",
-        "id" : 20
-    },
-    {
-        "name" : "minecraft:red_nether_brick",
-        "id" : 215
-    },
-    {
-        "name" : "minecraft:element_98",
-        "id" : -109
+        "name": "minecraft:cactus",
+        "id": 81
     },
     {
         "name" : "minecraft:element_99",
         "id" : -110
     },
     {
-        "name" : "minecraft:element_100",
-        "id" : -111
+        "name": "minecraft:element_105",
+        "id": -116
     },
     {
-        "name" : "minecraft:element_101",
-        "id" : -112
+        "name": "minecraft:element_106",
+        "id": -117
     },
     {
-        "name" : "minecraft:element_103",
-        "id" : -114
+        "name": "minecraft:cyan_glazed_terracotta",
+        "id": 229
     },
     {
-        "name" : "minecraft:element_106",
-        "id" : -117
+        "name": "minecraft:element_107",
+        "id": -118
     },
     {
-        "name" : "minecraft:element_108",
-        "id" : -119
+        "name": "minecraft:element_108",
+        "id": -119
     },
     {
-        "name" : "minecraft:element_109",
-        "id" : -120
+        "name": "minecraft:element_109",
+        "id": -120
     },
     {
-        "name" : "minecraft:element_110",
-        "id" : -121
+        "name": "minecraft:element_112",
+        "id": -123
     },
     {
-        "name" : "minecraft:element_111",
-        "id" : -122
+        "name": "minecraft:warped_button",
+        "id": -261
     },
     {
-        "name" : "minecraft:element_114",
-        "id" : -125
+        "name": "minecraft:element_113",
+        "id": -124
     },
     {
-        "name" : "minecraft:element_117",
-        "id" : -128
+        "name": "minecraft:birch_stairs",
+        "id": 135
     },
     {
-        "name" : "minecraft:slime",
-        "id" : 165
+        "name": "minecraft:element_114",
+        "id": -125
     },
     {
-        "name" : "minecraft:spruce_standing_sign",
-        "id" : -181
+        "name": "minecraft:composter",
+        "id": -213
     },
     {
-        "name" : "minecraft:element_118",
-        "id" : -129
+        "name": "minecraft:crying_obsidian",
+        "id": -289
     },
     {
-        "name" : "minecraft:gravel",
-        "id" : 13
+        "name": "minecraft:end_crystal",
+        "id": 426
     },
     {
-        "name" : "minecraft:detector_rail",
-        "id" : 28
+        "name": "minecraft:tripwire_hook",
+        "id": 131
     },
     {
-        "name" : "minecraft:oak_stairs",
-        "id" : 53
+        "name": "minecraft:blue_glazed_terracotta",
+        "id": 231
     },
     {
-        "name" : "minecraft:coal_ore",
-        "id" : 16
+        "name": "minecraft:daylight_detector_inverted",
+        "id": 178
     },
     {
-        "name" : "minecraft:diamond_block",
-        "id" : 57
+        "name": "minecraft:warped_trapdoor",
+        "id": -247
     },
     {
-        "name" : "minecraft:item.cake",
-        "id" : 92
+        "name": "minecraft:twisting_vines",
+        "id": -287
     },
     {
-        "name" : "minecraft:spruce_pressure_plate",
-        "id" : -154
+        "name": "minecraft:noteblock",
+        "id": 25
     },
     {
-        "name" : "minecraft:diamond_ore",
-        "id" : 56
+        "name": "minecraft:gravel",
+        "id": 13
     },
     {
-        "name" : "minecraft:furnace",
-        "id" : 61
+        "name": "minecraft:golden_rail",
+        "id": 27
     },
     {
-        "name" : "minecraft:underwater_torch",
-        "id" : 239
+        "name": "minecraft:warped_wall_sign",
+        "id": -253
     },
     {
-        "name" : "minecraft:web",
-        "id" : 30
+        "name": "minecraft:oak_stairs",
+        "id": 53
     },
     {
-        "name" : "minecraft:jungle_standing_sign",
-        "id" : -188
+        "name": "minecraft:grass",
+        "id": 2
     },
     {
-        "name" : "minecraft:standing_sign",
-        "id" : 63
+        "name": "minecraft:acacia_button",
+        "id": -140
     },
     {
-        "name" : "minecraft:lapis_ore",
-        "id" : 21
+        "name": "minecraft:snow",
+        "id": 80
     },
     {
-        "name" : "minecraft:beehive",
-        "id" : -219
+        "name": "minecraft:detector_rail",
+        "id": 28
     },
     {
-        "name" : "minecraft:item.bed",
-        "id" : 26
+        "name": "minecraft:dark_oak_trapdoor",
+        "id": -147
     },
     {
-        "name" : "minecraft:lapis_block",
-        "id" : 22
+        "name": "minecraft:spruce_pressure_plate",
+        "id": -154
     },
     {
-        "name" : "minecraft:stripped_acacia_log",
-        "id" : -8
+        "name": "minecraft:water",
+        "id": 9
     },
     {
-        "name" : "minecraft:dispenser",
-        "id" : 23
+        "name": "minecraft:furnace",
+        "id": 61
     },
     {
-        "name" : "minecraft:obsidian",
-        "id" : 49
+        "name": "minecraft:item.wooden_door",
+        "id": 64
     },
     {
-        "name" : "minecraft:brick_block",
-        "id" : 45
+        "name": "minecraft:gold_ore",
+        "id": 14
     },
     {
-        "name" : "minecraft:dried_kelp_block",
-        "id" : -139
+        "name": "minecraft:web",
+        "id": 30
     },
     {
-        "name" : "minecraft:structure_block",
-        "id" : 252
+        "name": "minecraft:unlit_redstone_torch",
+        "id": 75
     },
     {
-        "name" : "minecraft:pistonarmcollision",
-        "id" : 34
+        "name": "minecraft:ladder",
+        "id": 65
     },
     {
-        "name" : "minecraft:green_glazed_terracotta",
-        "id" : 233
+        "name": "minecraft:sweet_berry_bush",
+        "id": -207
     },
     {
-        "name" : "minecraft:acacia_trapdoor",
-        "id" : -145
+        "name": "minecraft:standing_sign",
+        "id": 63
     },
     {
-        "name" : "minecraft:carrots",
-        "id" : 141
+        "name": "minecraft:glass",
+        "id": 20
     },
     {
-        "name" : "minecraft:rail",
-        "id" : 66
+        "name": "minecraft:lapis_ore",
+        "id": 21
     },
     {
-        "name" : "minecraft:torch",
-        "id" : 50
+        "name": "minecraft:bookshelf",
+        "id": 47
     },
     {
-        "name" : "minecraft:mob_spawner",
-        "id" : 52
+        "name": "minecraft:item.bed",
+        "id": 26
     },
     {
-        "name" : "minecraft:lava_cauldron",
-        "id" : -210
+        "name": "minecraft:stripped_warped_hyphae",
+        "id": -301
     },
     {
-        "name" : "minecraft:redstone_wire",
-        "id" : 55
+        "name": "minecraft:wither_rose",
+        "id": -216
     },
     {
-        "name" : "minecraft:farmland",
-        "id" : 60
+        "name": "minecraft:wooden_pressure_plate",
+        "id": 72
     },
     {
-        "name" : "minecraft:wall_sign",
-        "id" : 68
+        "name": "minecraft:powered_comparator",
+        "id": 150
     },
     {
-        "name" : "minecraft:stone_pressure_plate",
-        "id" : 70
+        "name": "minecraft:lapis_block",
+        "id": 22
     },
     {
-        "name" : "minecraft:red_sandstone_stairs",
-        "id" : 180
+        "name": "minecraft:dispenser",
+        "id": 23
+    },
+    {
+        "name": "minecraft:item.wheat",
+        "id": 59
+    },
+    {
+        "name": "minecraft:item.spruce_door",
+        "id": 193
+    },
+    {
+        "name": "minecraft:diamond_ore",
+        "id": 56
+    },
+    {
+        "name": "minecraft:deadbush",
+        "id": 32
+    },
+    {
+        "name": "minecraft:pistonarmcollision",
+        "id": 34
+    },
+    {
+        "name": "minecraft:blackstone_stairs",
+        "id": -276
+    },
+    {
+        "name": "minecraft:dried_kelp_block",
+        "id": -139
+    },
+    {
+        "name": "minecraft:item.soul_campfire",
+        "id": -290
+    },
+    {
+        "name": "minecraft:green_glazed_terracotta",
+        "id": 233
+    },
+    {
+        "name": "minecraft:crimson_pressure_plate",
+        "id": -262
+    },
+    {
+        "name": "minecraft:spruce_fence_gate",
+        "id": 183
+    },
+    {
+        "name": "minecraft:iron_block",
+        "id": 42
+    },
+    {
+        "name": "minecraft:lever",
+        "id": 69
+    },
+    {
+        "name": "minecraft:mossy_cobblestone",
+        "id": 48
+    },
+    {
+        "name": "minecraft:torch",
+        "id": 50
+    },
+    {
+        "name": "minecraft:acacia_fence_gate",
+        "id": 187
+    },
+    {
+        "name": "minecraft:quartz_stairs",
+        "id": 156
+    },
+    {
+        "name": "minecraft:dragon_egg",
+        "id": 122
+    },
+    {
+        "name": "minecraft:lava_cauldron",
+        "id": -210
+    },
+    {
+        "name": "minecraft:jungle_standing_sign",
+        "id": -188
+    },
+    {
+        "name": "minecraft:redstone_wire",
+        "id": 55
+    },
+    {
+        "name": "minecraft:jungle_wall_sign",
+        "id": -189
+    },
+    {
+        "name": "minecraft:lit_furnace",
+        "id": 62
+    },
+    {
+        "name": "minecraft:beehive",
+        "id": -219
+    },
+    {
+        "name": "minecraft:crimson_wall_sign",
+        "id": -252
+    },
+    {
+        "name": "minecraft:stone_stairs",
+        "id": 67
+    },
+    {
+        "name": "minecraft:orange_glazed_terracotta",
+        "id": 221
+    },
+    {
+        "name": "minecraft:brick_stairs",
+        "id": 108
+    },
+    {
+        "name": "minecraft:wall_sign",
+        "id": 68
+    },
+    {
+        "name": "minecraft:warped_nylium",
+        "id": -233
+    },
+    {
+        "name": "minecraft:quartz_bricks",
+        "id": -304
     },
     {
         "name" : "minecraft:item.iron_door",
         "id" : 71
     },
     {
-        "name" : "minecraft:lit_redstone_ore",
-        "id" : 74
+        "name": "minecraft:redstone_ore",
+        "id": 73
     },
     {
-        "name" : "minecraft:stripped_jungle_log",
-        "id" : -7
+        "name": "minecraft:lectern",
+        "id": -194
     },
     {
-        "name" : "minecraft:unlit_redstone_torch",
-        "id" : 75
+        "name": "minecraft:gilded_blackstone",
+        "id": -281
     },
     {
         "name" : "minecraft:red_nether_brick_stairs",
         "id" : -184
     },
     {
-        "name" : "minecraft:redstone_torch",
-        "id" : 76
+        "name": "minecraft:basalt",
+        "id": -234
     },
     {
-        "name" : "minecraft:ice",
-        "id" : 79
-    },
-    {
-        "name" : "minecraft:snow",
-        "id" : 80
-    },
-    {
-        "name" : "minecraft:command_block",
-        "id" : 137
-    },
-    {
-        "name" : "minecraft:clay",
-        "id" : 82
-    },
-    {
-        "name" : "minecraft:jukebox",
-        "id" : 84
-    },
-    {
-        "name" : "minecraft:pumpkin",
-        "id" : 86
-    },
-    {
-        "name" : "minecraft:item.acacia_door",
-        "id" : 196
-    },
-    {
-        "name" : "minecraft:nether_brick_stairs",
-        "id" : 114
+        "name": "minecraft:stone_button",
+        "id": 77
     },
     {
         "name" : "minecraft:netherrack",
         "id" : 87
     },
     {
-        "name" : "minecraft:glowstone",
-        "id" : 89
+        "name": "minecraft:nether_brick_stairs",
+        "id": 114
     },
     {
-        "name" : "minecraft:hard_glass",
-        "id" : 253
+        "name": "minecraft:item.acacia_door",
+        "id": 196
     },
     {
-        "name" : "minecraft:portal",
-        "id" : 90
-    },
-    {
-        "name" : "minecraft:item.beetroot",
-        "id" : 244
+        "name": "minecraft:item.cake",
+        "id": 92
     },
     {
         "name" : "minecraft:unpowered_repeater",
         "id" : 93
     },
     {
-        "name" : "minecraft:invisiblebedrock",
-        "id" : 95
+        "name": "minecraft:powered_repeater",
+        "id": 94
     },
     {
-        "name" : "minecraft:trapdoor",
-        "id" : 96
+        "name": "minecraft:trapdoor",
+        "id": 96
     },
     {
-        "name" : "minecraft:item.jungle_door",
-        "id" : 195
+        "name": "minecraft:coral_fan_hang3",
+        "id": -137
     },
     {
-        "name" : "minecraft:iron_bars",
-        "id" : 101
+        "name": "minecraft:item.jungle_door",
+        "id": 195
     },
     {
-        "name" : "minecraft:chain_command_block",
-        "id" : 189
+        "name": "minecraft:glass_pane",
+        "id": 102
     },
     {
-        "name" : "minecraft:melon_block",
-        "id" : 103
+        "name": "minecraft:emerald_ore",
+        "id": 129
     },
     {
-        "name" : "minecraft:emerald_block",
-        "id" : 133
+        "name": "minecraft:crimson_planks",
+        "id": -242
     },
     {
-        "name" : "minecraft:chemical_heat",
-        "id" : 192
+        "name": "minecraft:crimson_stem",
+        "id": -225
     },
     {
-        "name" : "minecraft:melon_stem",
-        "id" : 105
+        "name": "minecraft:weeping_vines",
+        "id": -231
     },
     {
-        "name" : "minecraft:fence_gate",
-        "id" : 107
+        "name": "minecraft:pumpkin_stem",
+        "id": 104
     },
     {
-        "name" : "minecraft:brick_stairs",
-        "id" : 108
+        "name": "minecraft:emerald_block",
+        "id": 133
     },
     {
-        "name" : "minecraft:stone_brick_stairs",
-        "id" : 109
+        "name": "minecraft:melon_stem",
+        "id": 105
     },
     {
-        "name" : "minecraft:mycelium",
-        "id" : 110
+        "name": "minecraft:chemical_heat",
+        "id": 192
     },
     {
-        "name" : "minecraft:smooth_stone",
-        "id" : -183
+        "name": "minecraft:warped_wart_block",
+        "id": -227
     },
     {
-        "name" : "minecraft:nether_brick_fence",
-        "id" : 113
+        "name": "minecraft:vine",
+        "id": 106
     },
     {
-        "name" : "minecraft:item.nether_wart",
-        "id" : 115
+        "name": "minecraft:bamboo_sapling",
+        "id": -164
     },
     {
-        "name" : "minecraft:enchanting_table",
-        "id" : 116
+        "name": "minecraft:standing_banner",
+        "id": 176
     },
     {
-        "name" : "minecraft:end_portal",
-        "id" : 119
+        "name": "minecraft:mycelium",
+        "id": 110
     },
     {
-        "name" : "minecraft:dragon_egg",
-        "id" : 122
+        "name": "minecraft:nether_gold_ore",
+        "id": -288
     },
     {
-        "name" : "minecraft:granite_stairs",
-        "id" : -169
+        "name": "minecraft:nether_brick",
+        "id": 112
     },
     {
-        "name" : "minecraft:podzol",
-        "id" : 243
+        "name": "minecraft:warped_double_slab",
+        "id": -267
+    },
+    {
+        "name": "minecraft:nether_brick_fence",
+        "id": 113
+    },
+    {
+        "name": "minecraft:sandstone_stairs",
+        "id": 128
+    },
+    {
+        "name": "minecraft:item.nether_wart",
+        "id": 115
+    },
+    {
+        "name": "minecraft:enchanting_table",
+        "id": 116
+    },
+    {
+        "name": "minecraft:end_stone",
+        "id": 121
+    },
+    {
+        "name": "minecraft:redstone_lamp",
+        "id": 123
+    },
+    {
+        "name": "minecraft:jungle_stairs",
+        "id": 136
+    },
+    {
+        "name": "minecraft:dropper",
+        "id": 125
     },
     {
         "name" : "minecraft:activator_rail",
@@ -2520,36 +2804,20 @@
         "id" : 127
     },
     {
-        "name" : "minecraft:emerald_ore",
-        "id" : 129
-    },
-    {
-        "name" : "minecraft:brown_glazed_terracotta",
-        "id" : 232
-    },
-    {
-        "name" : "minecraft:pink_glazed_terracotta",
-        "id" : 226
-    },
-    {
-        "name" : "minecraft:observer",
-        "id" : 251
+        "name": "minecraft:soul_torch",
+        "id": -268
     },
     {
         "name" : "minecraft:info_update",
         "id" : 248
     },
     {
-        "name" : "minecraft:birch_stairs",
-        "id" : 135
+        "name": "minecraft:packed_ice",
+        "id": 174
     },
     {
         "name" : "minecraft:coral_fan_hang",
         "id" : -135
-    },
-    {
-        "name" : "minecraft:packed_ice",
-        "id" : 174
     },
     {
         "name" : "minecraft:item.flower_pot",
@@ -2568,243 +2836,395 @@
         "id" : 144
     },
     {
-        "name" : "minecraft:trapped_chest",
-        "id" : 146
-    },
-    {
-        "name" : "minecraft:light_weighted_pressure_plate",
-        "id" : 147
-    },
-    {
         "name" : "minecraft:heavy_weighted_pressure_plate",
         "id" : 148
     },
     {
-        "name" : "minecraft:daylight_detector",
-        "id" : 151
+        "name": "minecraft:purple_glazed_terracotta",
+        "id": 219
     },
     {
-        "name" : "minecraft:smooth_sandstone_stairs",
-        "id" : -177
+        "name": "minecraft:stripped_jungle_log",
+        "id": -7
     },
     {
-        "name" : "minecraft:repeating_command_block",
-        "id" : 188
+        "name": "minecraft:hardened_clay",
+        "id": 172
     },
     {
-        "name" : "minecraft:double_wooden_slab",
-        "id" : 157
+        "name": "minecraft:warped_planks",
+        "id": -243
     },
     {
-        "name" : "minecraft:dark_oak_stairs",
-        "id" : 164
+        "name": "minecraft:acacia_wall_sign",
+        "id": -191
     },
     {
-        "name" : "minecraft:iron_trapdoor",
-        "id" : 167
+        "name": "minecraft:purpur_stairs",
+        "id": 203
     },
     {
-        "name" : "minecraft:hardened_clay",
-        "id" : 172
+        "name": "minecraft:wall_banner",
+        "id": 177
     },
     {
-        "name" : "minecraft:coal_block",
-        "id" : 173
+        "name": "minecraft:spruce_trapdoor",
+        "id": -149
     },
     {
-        "name" : "minecraft:purpur_stairs",
-        "id" : 203
+        "name": "minecraft:repeating_command_block",
+        "id": 188
     },
     {
-        "name" : "minecraft:jungle_fence_gate",
-        "id" : 185
+        "name": "minecraft:item.chain",
+        "id": -286
     },
     {
-        "name" : "minecraft:dark_oak_fence_gate",
-        "id" : 186
+        "name": "minecraft:item.birch_door",
+        "id": 194
     },
     {
-        "name" : "minecraft:grass_path",
-        "id" : 198
+        "name": "minecraft:grass_path",
+        "id": 198
     },
     {
-        "name" : "minecraft:bone_block",
-        "id" : 216
+        "name": "minecraft:blackstone",
+        "id": -273
     },
     {
-        "name" : "minecraft:normal_stone_stairs",
-        "id" : -180
+        "name": "minecraft:chorus_flower",
+        "id": 200
     },
     {
-        "name" : "minecraft:chorus_flower",
-        "id" : 200
+        "name": "minecraft:normal_stone_stairs",
+        "id": -180
     },
     {
-        "name" : "minecraft:jungle_pressure_plate",
-        "id" : -153
+        "name": "minecraft:barrier",
+        "id": -161
     },
     {
-        "name" : "minecraft:end_bricks",
-        "id" : 206
+        "name": "minecraft:frosted_ice",
+        "id": 207
     },
     {
-        "name" : "minecraft:blue_glazed_terracotta",
-        "id" : 231
+        "name": "minecraft:structure_block",
+        "id": 252
     },
     {
-        "name" : "minecraft:movingblock",
-        "id" : 250
+        "name": "minecraft:allow",
+        "id": 210
     },
     {
-        "name" : "minecraft:light_blue_glazed_terracotta",
-        "id" : 223
+        "name": "minecraft:pink_glazed_terracotta",
+        "id": 226
     },
     {
-        "name" : "minecraft:nether_wart_block",
-        "id" : 214
+        "name": "minecraft:deny",
+        "id": 211
+    },
+    {
+        "name": "minecraft:border_block",
+        "id": 212
+    },
+    {
+        "name": "minecraft:movingblock",
+        "id": 250
+    },
+    {
+        "name": "minecraft:bone_block",
+        "id": 216
+    },
+    {
+        "name": "minecraft:structure_void",
+        "id": 217
     },
     {
         "name" : "minecraft:white_glazed_terracotta",
         "id" : 220
     },
     {
-        "name" : "minecraft:orange_glazed_terracotta",
-        "id" : 221
-    },
-    {
         "name" : "minecraft:magenta_glazed_terracotta",
         "id" : 222
     },
     {
-        "name" : "minecraft:yellow_glazed_terracotta",
-        "id" : 224
+        "name": "minecraft:lime_glazed_terracotta",
+        "id": 225
     },
     {
-        "name" : "minecraft:barrier",
-        "id" : -161
+        "name": "minecraft:gray_glazed_terracotta",
+        "id": 227
     },
     {
-        "name" : "minecraft:gray_glazed_terracotta",
-        "id" : 227
+        "name": "minecraft:brown_glazed_terracotta",
+        "id": 232
     },
     {
-        "name" : "minecraft:silver_glazed_terracotta",
-        "id" : 228
+        "name": "minecraft:red_glazed_terracotta",
+        "id": 234
     },
     {
-        "name" : "minecraft:chorus_plant",
-        "id" : 240
+        "name": "minecraft:crimson_nylium",
+        "id": -232
     },
     {
-        "name" : "minecraft:fire",
-        "id" : 51
+        "name": "minecraft:acacia_trapdoor",
+        "id": -145
     },
     {
-        "name" : "minecraft:item.camera",
-        "id" : 242
+        "name": "minecraft:smooth_sandstone_stairs",
+        "id": -177
     },
     {
-        "name" : "minecraft:stonecutter",
-        "id" : 245
+        "name": "minecraft:item.camera",
+        "id": 242
     },
     {
-        "name" : "minecraft:reserved6",
-        "id" : 255
+        "name": "minecraft:podzol",
+        "id": 243
     },
     {
-        "name" : "minecraft:dark_prismarine_stairs",
-        "id" : -3
+        "name": "minecraft:stonecutter",
+        "id": 245
     },
     {
-        "name" : "minecraft:prismarine_bricks_stairs",
-        "id" : -4
+        "name": "minecraft:netherreactor",
+        "id": 247
     },
     {
-        "name" : "minecraft:stripped_spruce_log",
-        "id" : -5
+        "name": "minecraft:prismarine_stairs",
+        "id": -2
     },
     {
-        "name" : "minecraft:stripped_dark_oak_log",
-        "id" : -9
+        "name": "minecraft:dark_prismarine_stairs",
+        "id": -3
     },
     {
-        "name" : "minecraft:hard_glass_pane",
-        "id" : 190
+        "name": "minecraft:stripped_spruce_log",
+        "id": -5
     },
     {
-        "name" : "minecraft:mossy_cobblestone_stairs",
-        "id" : -179
+        "name": "minecraft:stripped_birch_log",
+        "id": -6
     },
     {
-        "name" : "minecraft:smooth_red_sandstone_stairs",
-        "id" : -176
+        "name": "minecraft:stripped_dark_oak_log",
+        "id": -9
     },
     {
-        "name" : "minecraft:bamboo_sapling",
-        "id" : -164
+        "name": "minecraft:fire",
+        "id": 51
     },
     {
-        "name" : "minecraft:jungle_button",
-        "id" : -143
+        "name": "minecraft:hard_glass",
+        "id": 253
     },
     {
-        "name" : "minecraft:birch_wall_sign",
-        "id" : -187
+        "name": "minecraft:acacia_standing_sign",
+        "id": -190
     },
     {
-        "name" : "minecraft:spruce_wall_sign",
-        "id" : -182
+        "name": "minecraft:hard_glass_pane",
+        "id": 190
     },
     {
-        "name" : "minecraft:jungle_trapdoor",
-        "id" : -148
+        "name": "minecraft:mossy_cobblestone_stairs",
+        "id": -179
     },
     {
-        "name" : "minecraft:dark_oak_button",
-        "id" : -142
+        "name": "minecraft:crimson_fence_gate",
+        "id": -258
     },
     {
-        "name" : "minecraft:birch_trapdoor",
-        "id" : -146
+        "name": "minecraft:mossy_stone_brick_stairs",
+        "id": -175
     },
     {
-        "name" : "minecraft:jigsaw",
-        "id" : -211
+        "name": "minecraft:item.nether_sprouts",
+        "id": -238
     },
     {
-        "name" : "minecraft:acacia_pressure_plate",
-        "id" : -150
+        "name": "minecraft:polished_blackstone_brick_double_slab",
+        "id": -285
     },
     {
-        "name" : "minecraft:bubble_column",
-        "id" : -160
+        "name": "minecraft:cracked_polished_blackstone_bricks",
+        "id": -280
     },
     {
-        "name" : "minecraft:polished_diorite_stairs",
-        "id" : -173
+        "name": "minecraft:smooth_red_sandstone_stairs",
+        "id": -176
     },
     {
-        "name" : "minecraft:smooth_quartz_stairs",
-        "id" : -185
+        "name": "minecraft:shroomlight",
+        "id": -230
     },
     {
-        "name" : "minecraft:acacia_wall_sign",
-        "id" : -191
+        "name": "minecraft:stripped_crimson_hyphae",
+        "id": -300
     },
     {
-        "name" : "minecraft:lit_smoker",
-        "id" : -199
+        "name": "minecraft:crimson_button",
+        "id": -260
     },
     {
-        "name" : "minecraft:item.campfire",
-        "id" : -209
+        "name": "minecraft:soul_fire",
+        "id": -237
     },
     {
-        "name" : "minecraft:bee_nest",
-        "id" : -218
+        "name": "minecraft:polished_basalt",
+        "id": -235
     },
     {
-        "name" : "minecraft:honeycomb_block",
-        "id" : -221
+        "name": "minecraft:jungle_button",
+        "id": -143
+    },
+    {
+        "name": "minecraft:birch_pressure_plate",
+        "id": -151
+    },
+    {
+        "name": "minecraft:stripped_warped_stem",
+        "id": -241
+    },
+    {
+        "name": "minecraft:birch_wall_sign",
+        "id": -187
+    },
+    {
+        "name": "minecraft:jungle_trapdoor",
+        "id": -148
+    },
+    {
+        "name": "minecraft:item.kelp",
+        "id": -138
+    },
+    {
+        "name": "minecraft:birch_button",
+        "id": -141
+    },
+    {
+        "name": "minecraft:birch_trapdoor",
+        "id": -146
+    },
+    {
+        "name": "minecraft:bubble_column",
+        "id": -160
+    },
+    {
+        "name": "minecraft:polished_granite_stairs",
+        "id": -172
+    },
+    {
+        "name": "minecraft:polished_andesite_stairs",
+        "id": -174
+    },
+    {
+        "name": "minecraft:end_brick_stairs",
+        "id": -178
+    },
+    {
+        "name": "minecraft:spruce_wall_sign",
+        "id": -182
+    },
+    {
+        "name": "minecraft:chiseled_polished_blackstone",
+        "id": -279
+    },
+    {
+        "name": "minecraft:birch_standing_sign",
+        "id": -186
+    },
+    {
+        "name": "minecraft:darkoak_standing_sign",
+        "id": -192
+    },
+    {
+        "name": "minecraft:darkoak_wall_sign",
+        "id": -193
+    },
+    {
+        "name": "minecraft:lit_smoker",
+        "id": -199
+    },
+    {
+        "name": "minecraft:item.campfire",
+        "id": -209
+    },
+    {
+        "name": "minecraft:bee_nest",
+        "id": -218
+    },
+    {
+        "name": "minecraft:warped_fence_gate",
+        "id": -259
+    },
+    {
+        "name": "minecraft:warped_stem",
+        "id": -226
+    },
+    {
+        "name": "minecraft:blackstone_double_slab",
+        "id": -283
+    },
+    {
+        "name": "minecraft:target",
+        "id": -239
+    },
+    {
+        "name": "minecraft:crimson_trapdoor",
+        "id": -246
+    },
+    {
+        "name": "minecraft:polished_blackstone_brick_wall",
+        "id": -278
+    },
+    {
+        "name": "minecraft:warped_standing_sign",
+        "id": -251
+    },
+    {
+        "name": "minecraft:warped_stairs",
+        "id": -255
+    },
+    {
+        "name": "minecraft:crimson_fence",
+        "id": -256
+    },
+    {
+        "name": "minecraft:warped_pressure_plate",
+        "id": -263
+    },
+    {
+        "name": "minecraft:soul_lantern",
+        "id": -269
+    },
+    {
+        "name": "minecraft:blackstone_wall",
+        "id": -277
+    },
+    {
+        "name": "minecraft:polished_blackstone",
+        "id": -291
+    },
+    {
+        "name": "minecraft:polished_blackstone_stairs",
+        "id": -292
+    },
+    {
+        "name": "minecraft:polished_blackstone_pressure_plate",
+        "id": -295
+    },
+    {
+        "name": "minecraft:warped_hyphae",
+        "id": -298
+    },
+    {
+        "name": "minecraft:crimson_hyphae",
+        "id": -299
+    },
+    {
+        "name": "minecraft:cracked_nether_bricks",
+        "id": -303
     }
 ]


### PR DESCRIPTION
the Creative Net ID needs to be non-zero unique, so just using the item ID did not work for blocks that share IDs using meta/states.