### PR TITLE
Make possible cancelling and editing explosion when there is no entity

### DIFF
--- a/src/main/java/cn/nukkit/event/level/ExplodeEvent.java
+++ b/src/main/java/cn/nukkit/event/level/ExplodeEvent.java
@@ -1,0 +1,53 @@
+package cn.nukkit.event.level;
+
+import cn.nukkit.block.Block;
+import cn.nukkit.event.Cancellable;
+import cn.nukkit.event.HandlerList;
+import cn.nukkit.level.Level;
+import cn.nukkit.level.Position;
+
+import java.util.List;
+
+/**
+ * author: SergeyDertan
+ * Nukkit Project
+ */
+public class ExplodeEvent extends LevelEvent implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    protected final Position position;
+    protected List<Block> blocks;
+    protected double yield;
+
+    public static HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public ExplodeEvent(Level level, Position position, List<Block> blocks, double yield) {
+        super(level);
+        this.position = position;
+        this.blocks = blocks;
+        this.yield = yield;
+    }
+
+    public Position getPosition() {
+        return this.position;
+    }
+
+    public List<Block> getBlockList() {
+        return this.blocks;
+    }
+
+    public void setBlockList(List<Block> blocks) {
+        this.blocks = blocks;
+    }
+
+    public double getYield() {
+        return this.yield;
+    }
+
+    public void setYield(double yield) {
+        this.yield = yield;
+    }
+}

--- a/src/main/java/cn/nukkit/level/Explosion.java
+++ b/src/main/java/cn/nukkit/level/Explosion.java
@@ -14,6 +14,7 @@ import cn.nukkit.event.entity.EntityDamageByEntityEvent;
 import cn.nukkit.event.entity.EntityDamageEvent;
 import cn.nukkit.event.entity.EntityDamageEvent.DamageCause;
 import cn.nukkit.event.entity.EntityExplodeEvent;
+import cn.nukkit.event.level.ExplodeEvent;
 import cn.nukkit.inventory.InventoryHolder;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBlock;
@@ -126,6 +127,15 @@ public class Explosion {
 
         if (this.what instanceof Entity) {
             EntityExplodeEvent ev = new EntityExplodeEvent((Entity) this.what, this.source, this.affectedBlocks, yield);
+            this.level.getServer().getPluginManager().callEvent(ev);
+            if (ev.isCancelled()) {
+                return false;
+            } else {
+                yield = ev.getYield();
+                this.affectedBlocks = ev.getBlockList();
+            }
+        } else {
+            ExplodeEvent ev = new ExplodeEvent(this.level, this.source, this.affectedBlocks, yield);
             this.level.getServer().getPluginManager().callEvent(ev);
             if (ev.isCancelled()) {
                 return false;


### PR DESCRIPTION
For now if we want to make explosion and don`t want to break some blocks we need to hardcode explosion to remove blocks.