### PR TITLE
Fixes the Network raw inflater and deflater names

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -21,7 +21,6 @@ import cn.nukkit.event.entity.EntityDamageEvent.DamageCause;
 import cn.nukkit.event.entity.EntityDamageEvent.DamageModifier;
 import cn.nukkit.event.entity.ProjectileLaunchEvent;
 import cn.nukkit.event.inventory.InventoryCloseEvent;
-import cn.nukkit.event.inventory.InventoryOpenEvent;
 import cn.nukkit.event.inventory.InventoryPickupArrowEvent;
 import cn.nukkit.event.inventory.InventoryPickupItemEvent;
 import cn.nukkit.event.player.*;
@@ -4750,7 +4749,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         batchPayload[1] = buf;
         byte[] data = Binary.appendBytes(batchPayload);
         try {
-            batch.payload = Network.deflate_raw(data, Server.getInstance().networkCompressionLevel);
+            batch.payload = Network.deflateRaw(data, Server.getInstance().networkCompressionLevel);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -710,7 +710,7 @@ public class Server {
         } else {
             try {
                 byte[] data = Binary.appendBytes(payload);
-                this.broadcastPacketsCallback(Network.deflate_raw(data, this.networkCompressionLevel), targets);
+                this.broadcastPacketsCallback(Network.deflateRaw(data, this.networkCompressionLevel), targets);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/cn/nukkit/network/CompressBatchedPacket.java
+++ b/src/main/java/cn/nukkit/network/CompressBatchedPacket.java
@@ -36,7 +36,7 @@ public class CompressBatchedPacket extends AsyncTask {
     @Override
     public void onRun() {
         try {
-            this.finalData = Network.deflate_raw(data, level);
+            this.finalData = Network.deflateRaw(data, level);
             this.data = null;
         } catch (Exception e) {
             //ignore

--- a/src/main/java/cn/nukkit/network/CompressBatchedTask.java
+++ b/src/main/java/cn/nukkit/network/CompressBatchedTask.java
@@ -36,7 +36,7 @@ public class CompressBatchedTask extends AsyncTask {
     @Override
     public void onRun() {
         try {
-            this.finalData = Network.deflate_raw(this.data, this.level);
+            this.finalData = Network.deflateRaw(this.data, this.level);
             this.data = null;
         } catch (Exception e) {
             //ignore

--- a/src/main/java/cn/nukkit/network/Network.java
+++ b/src/main/java/cn/nukkit/network/Network.java
@@ -64,7 +64,7 @@ public class Network {
         this.server = server;
     }
 
-    public static byte[] inflate_raw(byte[] data) throws IOException, DataFormatException {
+    public static byte[] inflateRaw(byte[] data) throws IOException, DataFormatException {
         Inflater inflater = INFLATER_RAW.get();
         inflater.reset();
         inflater.setInput(data);
@@ -80,7 +80,7 @@ public class Network {
         return bos.toByteArray();
     }
 
-    public static byte[] deflate_raw(byte[] data, int level) throws IOException {
+    public static byte[] deflateRaw(byte[] data, int level) throws IOException {
         Deflater deflater = DEFLATER_RAW.get();
         deflater.reset();
         deflater.setLevel(level);
@@ -97,7 +97,7 @@ public class Network {
         return bos.toByteArray();
     }
 
-    public static byte[] deflate_raw(byte[][] datas, int level) throws IOException {
+    public static byte[] deflateRaw(byte[][] datas, int level) throws IOException {
         Deflater deflater = DEFLATER_RAW.get();
         deflater.reset();
         deflater.setLevel(level);
@@ -207,7 +207,7 @@ public class Network {
     public void processBatch(BatchPacket packet, Player player) {
         byte[] data;
         try {
-            data = Network.inflate_raw(packet.payload);
+            data = Network.inflateRaw(packet.payload);
             //data = Zlib.inflate(packet.payload, 2 * 1024 * 1024); // Max 2MB
         } catch (Exception e) {
             log.debug("Exception while inflating batch packet", e);

--- a/src/main/java/cn/nukkit/network/RakNetInterface.java
+++ b/src/main/java/cn/nukkit/network/RakNetInterface.java
@@ -259,7 +259,7 @@ public class RakNetInterface implements ServerInstance, AdvancedSourceInterface 
                 }
                 buffer = packet.getBuffer();
                 try {
-                    buffer = Network.deflate_raw(
+                    buffer = Network.deflateRaw(
                             Binary.appendBytes(Binary.writeUnsignedVarInt(buffer.length), buffer),
                             Server.getInstance().networkCompressionLevel);
                 } catch (Exception e) {

--- a/src/main/java/cn/nukkit/network/protocol/DataPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/DataPacket.java
@@ -69,7 +69,7 @@ public abstract class DataPacket extends BinaryStream implements Cloneable {
         batchPayload[1] = buf;
         byte[] data = Binary.appendBytes(batchPayload);
         try {
-            batch.payload = Network.deflate_raw(data, level);
+            batch.payload = Network.deflateRaw(data, level);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This PR renames the `Network.deflate_raw` and `Network.inflate_raw` methods to `Network.deflateRaw` and `Network.inflateRaw` to match the java method naming standard.