### PR TITLE
Update Korean translation

### DIFF
--- a/src/main/resources/lang/kor/lang.ini
+++ b/src/main/resources/lang/kor/lang.ini
@@ -234,7 +234,7 @@ nukkit.level.unloading="{%0}" 레벨을 언로드하는 중입니다
 nukkit.level.updating="{%0}"의 레벨 데이터가 오래되었으므로 형식을 변환합니다
 
 nukkit.server.start=Minecraft: BE 서버 버전 {%0}을(를) 시작하는 중입니다
-nukkit.server.networkError=[네트워크] {%0} 인터페이스를 중지했습니다. 원인: {%1}
+nukkit.server.networkError=[네트워크] {%0} 인터페이스를 중지했습니다. 사유: {%1}
 nukkit.server.networkStart={%0}:{%1}에서 서버를 여는 중입니다
 nukkit.server.info=이 서버는 {%0} 버전 {%1} "{%2}"(API {%3})을(를) 실행하고 있습니다
 nukkit.server.info.extended=이 서버는 Minecraft: BE {%4}(프로토콜 버전 {%5})용 API 버전 {%3}을(를) 구현하는 {%0} {%1} 「{%2}」을(를) 실행하고 있습니다
@@ -336,7 +336,7 @@ nukkit.bugreport.archive=버그 보고서가 만들어졌습니다: {%0}
 
 nukkit.player.invalidMove={%0}이(가) 잘못 움직였습니다!
 nukkit.player.logIn={%0}[/{%1}:{%2}]이(가) 개체 ID {%3}(으)로 ({%4}, {%5}, {%6}, {%7})에서 로그인했습니다
-nukkit.player.logOut={%0}[/{%1}:{%2}]이(가) 로그아웃했습니다. 원인: {%3}
+nukkit.player.logOut={%0}[/{%1}:{%2}]이(가) 로그아웃했습니다. 사유: {%3}
 nukkit.player.invalidEntity={%0}이(가) 잘못된 개체를 공격하려고 했습니다
 
 nukkit.plugin.load={%0}을(를) 불러오는 중입니다

--- a/src/main/resources/lang/kor/nukkit.yml
+++ b/src/main/resources/lang/kor/nukkit.yml
@@ -81,7 +81,7 @@ player:
  save-player-data: true
  #스킨 변경 작업 간 시간(초)입니다. 대기 시간을 원하지 않으면 0으로 설정합니다
  skin-change-cooldown: 15
- #개체를 공격하면 달리기가 초기화되며, 여기에서 사용하지 않도록 설정할 수 있습니다
+ #개체를 공격하면 달리기가 초기화됩니다. 여기에서 사용하지 않도록 설정할 수 있습니다
  attack-stop-sprint: true
 
 aliases:


### PR DESCRIPTION
This pull request updates the Korean translation.

Please note that the translation is mostly based on the translation of Minecraft: Java Edition. I know this might cause confusion for some users, but the translation of Minecraft: Bedrock Edition is of poor quality in many languages. Since most players prefer the Java Edition translation anyway, and this project is not endorsed by Mojang or Microsoft, I believe it would be more beneficial to follow the Java Edition translation. (Not to mention that they recently changed the translations in v1.26.10.26 to use the Java Edition translations for many game terms...)