### PR TITLE
Fix offline consumer not skipping JWT signature verification

### DIFF
--- a/src/main/java/cn/nukkit/network/encryption/EncryptionUtils.java
+++ b/src/main/java/cn/nukkit/network/encryption/EncryptionUtils.java
@@ -76,6 +76,7 @@ public class EncryptionUtils {
             .build();
     private static final JwtConsumer OFFLINE_CONSUMER = new JwtConsumerBuilder()
             .setSkipAllValidators()
+            .setSkipSignatureVerification()
             .setRequireExpirationTime()
             .setSkipDefaultAudienceValidation()
             .build();


### PR DESCRIPTION
The offline consumer was missing `.setSkipSignatureVerification()`, so jose4j was trying to resolve the `x5u` header as a URL instead of skipping it.