### PR TITLE
Fix inventory slot null and empty item handling

### DIFF
--- a/src/main/java/cn/nukkit/inventory/BaseInventory.java
+++ b/src/main/java/cn/nukkit/inventory/BaseInventory.java
@@ -105,18 +105,31 @@ public abstract class BaseInventory implements Inventory {
     @Override
     public Item getItem(int index) {
         Item get = this.slots.get(index);
-        return get == null ? new ItemBlock(Block.get(BlockID.AIR), null, 0) : get.clone();
+        return get == null || get.isNull() ? new ItemBlock(Block.get(BlockID.AIR), null, 0) : get.clone();
     }
 
     @Override
     public Item getItemFast(int index) {
         Item get = this.slots.get(index);
-        return get == null ? air : get;
+        return get == null || get.isNull() ? air : get;
     }
 
     @Override
     public Map<Integer, Item> getContents() {
-        return new HashMap<>(this.slots);
+        Map<Integer, Item> newSlotMap = new HashMap<>(this.slots.size());
+        for (Map.Entry<Integer, Item> itemEntry : this.slots.entrySet()) {
+            int index = itemEntry.getKey();
+            if (index < 0 || index >= this.size) {
+                continue;
+            }
+
+            Item item = itemEntry.getValue();
+            if (item == null || item.isNull()) {
+                continue;
+            }
+            newSlotMap.put(itemEntry.getKey(), item);
+        }
+        return newSlotMap;
     }
 
     @Override
@@ -150,7 +163,11 @@ public abstract class BaseInventory implements Inventory {
 
     @Override
     public boolean setItem(int index, Item item, boolean send) {
-        //item = item.clone();
+        if (item == null) {
+            return this.clear(index, send);
+        }
+
+        item = item.clone();
         if (index < 0 || index >= this.size) {
             return false;
         } else if (item.getId() == 0 || item.getCount() <= 0) {
@@ -255,7 +272,7 @@ public abstract class BaseInventory implements Inventory {
             this.setItem(slot, item);
         }
     }
-    
+
     @Override
     public boolean canAddItem(Item item) {
         int count = item.getCount();
@@ -406,7 +423,7 @@ public abstract class BaseInventory implements Inventory {
 
     @Override
     public void clearAll() {
-        for (Integer index : this.getContents().keySet()) {
+        for (Integer index : new ArrayList<>(this.slots.keySet())) {
             this.clear(index);
         }
     }
@@ -486,12 +503,14 @@ public abstract class BaseInventory implements Inventory {
 
     @Override
     public boolean isFull() {
-        if (this.slots.size() < this.getSize()) {
-            return false;
-        }
+        for (int i = 0; i < this.getSize(); ++i) {
+            Item item = this.slots.get(i);
+            if (item == null || item.isNull()) {
+                return false;
+            }
 
-        for (Item item : this.slots.values()) {
-            if (item == null || item.getId() == 0 || item.getCount() < item.getMaxStackSize() || item.getCount() < this.maxStackSize) {
+            int maxStackSize = Math.min(item.getMaxStackSize(), this.getMaxStackSize());
+            if (item.getCount() < maxStackSize) {
                 return false;
             }
         }
@@ -515,17 +534,18 @@ public abstract class BaseInventory implements Inventory {
     }
 
     public int getFreeSpace(Item item) {
-        int maxStackSize = Math.min(item.getMaxStackSize(), this.maxStackSize);
-        int space = (this.getSize() - this.slots.size()) * maxStackSize;
+        int maxStackSize = Math.min(item.getMaxStackSize(), this.getMaxStackSize());
+        int space = 0;
 
-        for (Item slot : this.getContents().values()) {
-            if (slot == null || slot.getId() == 0) {
+        for (int i = 0; i < this.getSize(); ++i) {
+            Item slot = this.slots.get(i);
+            if (slot == null || slot.isNull()) {
                 space += maxStackSize;
                 continue;
             }
 
             if (slot.equals(item, true, true)) {
-                space += maxStackSize - slot.getCount();
+                space += Math.max(0, maxStackSize - slot.getCount());
             }
         }
 

--- a/src/main/java/cn/nukkit/inventory/DoubleChestInventory.java
+++ b/src/main/java/cn/nukkit/inventory/DoubleChestInventory.java
@@ -61,30 +61,39 @@ public class DoubleChestInventory extends ContainerInventory implements Inventor
 
     @Override
     public Item getItem(int index) {
-        return index < this.left.getSize() ? this.left.getItem(index) : this.right.getItem(index - this.right.getSize());
+        return index < this.left.getSize() ? this.left.getItem(index) : this.right.getItem(index - this.left.getSize());
     }
 
     @Override
     public Item getItemFast(int index) {
-        return index < this.left.getSize() ? this.left.getItemFast(index) : this.right.getItemFast(index - this.right.getSize());
+        return index < this.left.getSize() ? this.left.getItemFast(index) : this.right.getItemFast(index - this.left.getSize());
     }
 
     @Override
     public boolean setItem(int index, Item item, boolean send) {
-        return index < this.left.getSize() ? this.left.setItem(index, item, send) : this.right.setItem(index - this.right.getSize(), item, send);
+        return index < this.left.getSize() ? this.left.setItem(index, item, send) : this.right.setItem(index - this.left.getSize(), item, send);
     }
 
     @Override
     public boolean clear(int index) {
-        return index < this.left.getSize() ? this.left.clear(index) : this.right.clear(index - this.right.getSize());
+        return this.clear(index, true);
+    }
+
+    @Override
+    public boolean clear(int index, boolean send) {
+        return index < this.left.getSize() ? this.left.clear(index, send) : this.right.clear(index - this.left.getSize(), send);
     }
 
     @Override
     public Map<Integer, Item> getContents() {
         Map<Integer, Item> contents = new HashMap<>();
 
-        for (int i = 0; i < this.getSize(); ++i) {
-            contents.put(i, this.getItem(i));
+        for (Map.Entry<Integer, Item> entry : this.left.getContents().entrySet()) {
+            contents.put(entry.getKey(), entry.getValue());
+        }
+
+        for (Map.Entry<Integer, Item> entry : this.right.getContents().entrySet()) {
+            contents.put(entry.getKey() + this.left.getSize(), entry.getValue());
         }
 
         return contents;

--- a/src/main/java/cn/nukkit/inventory/PlayerInventory.java
+++ b/src/main/java/cn/nukkit/inventory/PlayerInventory.java
@@ -14,6 +14,7 @@ import cn.nukkit.item.ItemBlock;
 import cn.nukkit.network.protocol.*;
 import cn.nukkit.network.protocol.types.ContainerIds;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 /**
@@ -204,7 +205,7 @@ public class PlayerInventory extends BaseInventory {
     }
 
     public boolean setArmorItem(int index, Item item, boolean ignoreArmorEvents) {
-        return this.setItem(this.getSize() + index, item, ignoreArmorEvents);
+        return this.setItem(this.getSize() + index, item, true, ignoreArmorEvents);
     }
 
     public Item getHelmet() {
@@ -262,13 +263,17 @@ public class PlayerInventory extends BaseInventory {
 
     @Override
     public boolean setItem(int index, Item item, boolean send) {
+        return setItem(index, item, send, false);
+    }
+
+    private boolean setItem(int index, Item item, boolean send, boolean ignoreArmorEvents) {
         if (index < 0 || index >= this.size) {
             return false;
-        } else if (item.getId() == 0 || item.getCount() <= 0) {
+        } else if (item == null || item.getId() == 0 || item.getCount() <= 0) {
             return this.clear(index, send);
         }
 
-        if (index >= this.getSize()) { // Armor change
+        if (!ignoreArmorEvents && index >= this.getSize()) { // Armor change
             EntityArmorChangeEvent ev = new EntityArmorChangeEvent(this.getHolder(), this.getItem(index), item, index);
             Server.getInstance().getPluginManager().callEvent(ev);
             if (ev.isCancelled() && this.getHolder() != null) {
@@ -294,9 +299,13 @@ public class PlayerInventory extends BaseInventory {
 
     @Override
     public boolean clear(int index, boolean send) {
-        Item old = this.slots.get(index);
-        if (old != null) {
+        if (index < 0 || index >= this.size) {
+            this.slots.remove(index);
+            return true;
+        }
+        if (this.slots.containsKey(index)) {
             Item item = new ItemBlock(Block.get(BlockID.AIR), null, 0);
+            Item old = this.getItem(index);
             if (index >= this.getSize() && index < this.size) {
                 EntityArmorChangeEvent ev = new EntityArmorChangeEvent(this.getHolder(), old, item, index);
                 Server.getInstance().getPluginManager().callEvent(ev);
@@ -346,8 +355,7 @@ public class PlayerInventory extends BaseInventory {
 
     @Override
     public void clearAll() {
-        int limit = this.getSize() + 4;
-        for (int index = 0; index < limit; ++index) {
+        for (Integer index : new ArrayList<>(this.slots.keySet())) {
             this.clear(index);
         }
         getHolder().getOffhandInventory().clearAll();
@@ -387,7 +395,7 @@ public class PlayerInventory extends BaseInventory {
                 items[i] = new ItemBlock(Block.get(BlockID.AIR), null, 0);
             }
 
-            if (items[i].getId() == Item.AIR) {
+            if (items[i].isNull()) {
                 this.clear(this.getSize() + i);
             } else {
                 this.setItem(this.getSize() + i, items[i]);

--- a/src/main/java/cn/nukkit/inventory/PlayerUIComponent.java
+++ b/src/main/java/cn/nukkit/inventory/PlayerUIComponent.java
@@ -4,6 +4,7 @@ import cn.nukkit.Player;
 import cn.nukkit.item.Item;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -60,8 +61,13 @@ public class PlayerUIComponent extends BaseInventory {
 
     @Override
     public Map<Integer, Item> getContents() {
-        Map<Integer, Item> contents = playerUI.getContents();
-        contents.keySet().removeIf(slot -> slot < offset || slot > offset + size);
+        Map<Integer, Item> contents = new HashMap<>();
+        for (Map.Entry<Integer, Item> entry : playerUI.getContents().entrySet()) {
+            int slot = entry.getKey();
+            if (slot >= offset && slot < offset + size) {
+                contents.put(slot - offset, entry.getValue());
+            }
+        }
         return contents;
     }
 


### PR DESCRIPTION
This PR fixes inconsistent inventory slot handling when `BaseInventory.slots` contains invalid entries, such as `null`, air items, zero-count items, or out-of-range slot keys.

  One real bug this fixes comes from `getContents()` returning mutable `Item` instances. A caller could get an item from `getContents()` and modify it directly, for example by calling `setCount(0)`. Since that `Item` could still be the same
  object stored inside the inventory, the player inventory could end up containing an item stack with a count of 0.

  That is not a valid inventory item. However, because some inventory methods still treated it as a real item, other systems could read it later and run incorrect logic under the assumption that every stored item has a positive count.

  This PR does not introduce a new rule. It makes an existing rule consistent.

  For example, `addItem()` already treats items with `count <= 0` as empty slots when inserting items:

  ```java
  if (item.getId() == Item.AIR || item.getCount() <= 0) {
      emptySlots.add(i);
  }
```
  So the inventory code already considered zero-count and negative-count items to be empty slots. The problem was that this rule was only applied in some places. Other methods could still expose, count, or keep those invalid items as if they
  were valid inventory contents.

  After this change, null, air items, and items with count <= 0 are consistently treated as empty slots when inventory contents are read, listed, cleared, or used for capacity checks.