### PR TITLE
fix(item): deep copy cached NBT when cloning items

### DIFF
--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -1054,6 +1054,8 @@ public class Item implements Cloneable, BlockID, ItemID, ProtocolInfo {
         try {
             Item item = (Item) super.clone();
             item.tags = this.tags.clone();
+            item.cachedNBT = this.cachedNBT == null ? null : this.cachedNBT.copy();
+            item.persistentContainer = null;
             return item;
         } catch (CloneNotSupportedException e) {
             return null;

--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -1054,7 +1054,7 @@ public class Item implements Cloneable, BlockID, ItemID, ProtocolInfo {
         try {
             Item item = (Item) super.clone();
             item.tags = this.tags.clone();
-            item.cachedNBT = this.cachedNBT == null ? null : this.cachedNBT.copy();
+            item.cachedNBT = null;
             item.persistentContainer = null;
             return item;
         } catch (CloneNotSupportedException e) {


### PR DESCRIPTION
Item#clone currently copies the serialized tag bytes, but cachedNBT and the persistent data wrapper can still be shared through Object#clone. This can let mutations on a cloned item's named tag data affect the source item if the source had already decoded its NBT.

This patch clears cachedNBT and resets the persistent data container wrapper on the cloned item, forcing both to be rebuilt lazily from the clone's own state.

test plugin [TestCloneItemEdit](https://github.com/NuStarWorld/TestCloneItemEdit/blob/master/core/src/main/java/top/nustar/nukkit/testcloneitemedit/core/TestCommand.java)